### PR TITLE
Vagrant fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,4 +98,3 @@ android:
     - ./native/build_cronet.sh debug  # build-envoy.sh wants both release and debug
     - cp native/cronet-debug.aar android/cronet/
     - ./android/build-envoy.sh
-    #- ./apps/build-apps.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,9 +81,12 @@ android:
     - mkdir -p chromium
     - cd chromium
     - export CHROMIUM_SRC_ROOT=`pwd`/src
-    - fetch android
+    - fetch --no-history android
     - cd src
     - build/install-build-deps-android.sh
+    - git fetch origin refs/tags/87.0.4280.66:refs/tags/87.0.4280.66 --verbose
+    - git checkout -B 87.0.4280.66 tags/87.0.4280.66
+    - gclient sync --reset --with_branch_heads
 
     # set up dev env in case manual work is needed
     - echo >> /etc/profile.d/env.sh
@@ -93,7 +96,6 @@ android:
 
     - cd $CI_PROJECT_DIR
     - sed -i 's,/bin/bash$,/bin/bash -x,' a*/*.sh # show commands as they run
-    - ./native/checkout-to-tag.sh
     - ./native/build_cronet.sh release
     - ./native/build_cronet.sh debug  # build-envoy.sh wants both release and debug
     - cp native/cronet-debug.aar android/cronet/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,6 +55,7 @@ android:
         ninja-build
         openjdk-8-jdk-headless
         pkg-config
+        python
         python3
         python3-requests
         unzip
@@ -80,16 +81,9 @@ android:
     - mkdir -p chromium
     - cd chromium
     - export CHROMIUM_SRC_ROOT=`pwd`/src
-    - fetch --no-history android
+    - fetch android
     - cd src
     - build/install-build-deps-android.sh
-    - gclient runhooks
-    - gclient sync
-    - ./components/cronet/tools/cr_cronet.py gn --out_dir=out/Cronet
-
-    - ninja -C out/Cronet cronet_package
-    - ./components/cronet/tools/cr_cronet.py gn --release
-    - ninja -C out/Release cronet_package
 
     # set up dev env in case manual work is needed
     - echo >> /etc/profile.d/env.sh
@@ -99,9 +93,9 @@ android:
 
     - cd $CI_PROJECT_DIR
     - sed -i 's,/bin/bash$,/bin/bash -x,' a*/*.sh # show commands as they run
-    - ./native/checkout-to-tag.sh 81.0.4020.0
+    - ./native/checkout-to-tag.sh
     - ./native/build_cronet.sh release
     - ./native/build_cronet.sh debug  # build-envoy.sh wants both release and debug
     - cp native/cronet-debug.aar android/cronet/
     - ./android/build-envoy.sh
-    - ./apps/build-apps.sh
+    #- ./apps/build-apps.sh


### PR DESCRIPTION
I'm not sure this is ready to merge, I haven't tested all the changes, but I'm creating this PR to share with @eighthave and others, and have a place to talk.

changes:

* add `python` to the installed packages... `checkout-to-tag.sh` calls `build/install-build-deps.sh` it calls `python` which fails silently (this doesn't seem to cause any problems though)
* `checkout-to-tag.sh` doesn't take arguments, so I removed the argument. It uses the version in the script, currently `87.0.4280.66`
* removed a block of `gclient`, `gn`, and `ninja` calls... I don't think this is needed, `build_cronet.sh` seems to take care of what's necessary
* removed the call to `apps/build-apps.sh` because that's not working
* replaced the call to checkout-to-tag.sh with the minimal git fetches/gclient sync to build