### PR TITLE
improved feedback from services

### DIFF
--- a/android/demo/src/main/java/com/example/myapplication/MainActivity.java
+++ b/android/demo/src/main/java/com/example/myapplication/MainActivity.java
@@ -44,7 +44,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.greatfire.envoy.NetworkIntentServiceKt.BROADCAST_VALID_URL_FOUND;
+import static org.greatfire.envoy.NetworkIntentServiceKt.BROADCAST_URL_VALIDATION_SUCCEEDED;
 import static org.greatfire.envoy.NetworkIntentServiceKt.EXTENDED_DATA_VALID_URLS;
 
 public class MainActivity extends FragmentActivity {
@@ -64,7 +64,7 @@ public class MainActivity extends FragmentActivity {
         setContentView(R.layout.activity_main);
 
         // register to receive test results
-        LocalBroadcastManager.getInstance(this).registerReceiver(mBroadcastReceiver, new IntentFilter(BROADCAST_VALID_URL_FOUND));
+        LocalBroadcastManager.getInstance(this).registerReceiver(mBroadcastReceiver, new IntentFilter(BROADCAST_URL_VALIDATION_SUCCEEDED));
 
         String ssUri = "ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpwYXNz@127.0.0.1:1234";
         Intent shadowsocksIntent = new Intent(this, ShadowsocksService.class);


### PR DESCRIPTION
These changes address several issues I found when integrating Envoy with other applications:
 - the app may attempt to make network connections before the proxy has been set up.
 - sometimes the local url of the shadowsocks service is submitted before the shadowsocks service has started so the validation fails.
 - the shadowsocks process may continue running after the app stops.  subsequent attempts will fail because the port is already bound.

To address these issues, several changes have been made:
 - there is now a broadcast when the shadowsocks service has been started, so the app can wait for this broadcast before validating urls.
 - there is now a broadcast if starting the shadowsocks service or validating the urls fail, so the app can display an error or handle network activity as necessary.
 - a reference to the shadowsocks process is now stored in memory so that it can be killed when the application closes.