### PR TITLE
shadowsocks fix

### DIFF
--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/ShadowsocksService.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/ShadowsocksService.kt
@@ -1,12 +1,18 @@
 package org.greatfire.envoy
 
 import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.app.Service
 import android.content.Intent
 import android.os.Binder
+import android.os.Build
 import android.os.IBinder
+import android.os.SystemClock
 import android.util.Base64
 import android.util.Log
+import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
@@ -40,6 +46,28 @@ class ShadowsocksService : Service() {
         val configFile = File(ContextCompat.getNoBackupFilesDir(this), "shadowsocks.conf")
         // val configFile = File("/data/local/tmp/shadowsocks-envoy.conf")
         configFile.writeText(config.toString())
+
+        val channelId = "shadowsocks-channel"
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val name = "shadowsocks-channel"
+            val channel = NotificationChannel(
+                channelId, name, NotificationManager.IMPORTANCE_LOW)
+            val notificationManager = getSystemService(NotificationManager::class.java)
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        @Suppress("DEPRECATION")
+        val notification: Notification = NotificationCompat.Builder(this, channelId)
+            .setAutoCancel(false)
+            .setOngoing(true)
+            .setContentTitle("Shadowsocks service is running")
+            .setContentText("Shadowsocks service is running")
+            .setPriority(Notification.PRIORITY_LOW)
+            .setTicker("Shadowsocks service is running")
+            .build()
+
+        startForeground(SystemClock.uptimeMillis().toInt(), notification)
 
         val nativeLibraryDir = applicationInfo.nativeLibraryDir
         val executableFile = File(nativeLibraryDir, "libsslocal.so")


### PR DESCRIPTION
I had previously removed the notification code because we had no reason to present a notification for the shadowsocks service.  However, a foreground service must call startForeground() and startForeground() requires a non-null notification argument so most of the original code has been restored.  Notification.Builder() has been replaced with NotificationCompat.Builder() and has been tested on Android 10 and 7. 