### PR TITLE
Use same builder params for testing urls

### DIFF
--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/CronetNetworking.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/CronetNetworking.kt
@@ -52,7 +52,6 @@ object CronetNetworking {
             val cacheDir = File(context.cacheDir, "cronet-cache")
             cacheDir.mkdirs()
             mCronetEngine = CronetEngine.Builder(context)
-                    // .setUserAgent("curl/7.66.0")
                     .enableBrotli(true)
                     .enableHttp2(true)
                     .enableQuic(true)

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/NetworkIntentService.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/NetworkIntentService.kt
@@ -414,8 +414,12 @@ class NetworkIntentService : IntentService("NetworkIntentService") {
         val executor: Executor = Executors.newSingleThreadExecutor()
         val myBuilder = CronetEngine.Builder(applicationContext)
         val cronetEngine: CronetEngine = myBuilder
+            .enableBrotli(true)
+            .enableHttp2(true)
+            .enableQuic(true)
             .setEnvoyUrl(envoyUrl)
-            .setUserAgent(DEFAULT_USER_AGENT).build()
+            .setUserAgent(DEFAULT_USER_AGENT)
+            .build()
         val requestBuilder = cronetEngine.newUrlRequestBuilder(
             captive_portal_url,
             MyUrlRequestCallback(envoyUrl, envoyService, hysteriaCert, dnsttConfig, dnsttUrls),


### PR DESCRIPTION
This sets the same options on the CronetEngine.Builder for testing proxies as we use in the `initializeCronetEngine` call, specifically I added:

```
.enableBrotli(true)
.enableHttp2(true)
.enableQuic(true)
```