### PR TITLE
fixes to run build script with flatdir repos

### DIFF
--- a/android/build-envoy.sh
+++ b/android/build-envoy.sh
@@ -16,7 +16,7 @@ export CMAKE_VERSION="3.10.2.4988404"
 export ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT:-$PWD/android-sdk-linux}
 export CMAKE_HOME=$ANDROID_SDK_ROOT/cmake/${CMAKE_VERSION}/bin
 export PATH=$PATH:$ANDROID_SDK_ROOT/platform-tools:$CMAKE_HOME
-export sdkmanager=$ANDROID_SDK_ROOT/tools/bin/sdkmanager
+export sdkmanager=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager
 
 set -euo pipefail
 if [ ! -e $sdkmanager ]; then
@@ -42,5 +42,8 @@ cp "../native/cronet-$BUILD.aar" ./demo/cronet/
 if [[ $BUILD == "debug" ]]; then
     ./gradlew assembleDebug $BUILD_ARGS
 else
+    # lint checks debug dependencies for release builds
+    cp "../native/cronet-debug.aar" ./envoy/cronet/
+    cp "../native/cronet-debug.aar" ./demo/cronet/
     ./gradlew assembleRelease $BUILD_ARGS
 fi

--- a/android/build-envoy.sh
+++ b/android/build-envoy.sh
@@ -42,8 +42,5 @@ cp "../native/cronet-$BUILD.aar" ./demo/cronet/
 if [[ $BUILD == "debug" ]]; then
     ./gradlew assembleDebug $BUILD_ARGS
 else
-    # lint checks debug dependencies for release builds
-    cp "../native/cronet-debug.aar" ./envoy/cronet/
-    cp "../native/cronet-debug.aar" ./demo/cronet/
     ./gradlew assembleRelease $BUILD_ARGS
 fi

--- a/android/demo/build.gradle
+++ b/android/demo/build.gradle
@@ -50,5 +50,6 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
 
-    // api(name: 'cronet-debug', ext: 'aar')
+    // debugApi(name: 'cronet-debug', ext: 'aar')
+    // releaseApi(name: 'cronet-release', ext: 'aar')
 }

--- a/android/envoy/build.gradle
+++ b/android/envoy/build.gradle
@@ -3,6 +3,11 @@ apply plugin: 'kotlin-android'
 
 android {
 
+    // exclude lint task from demo project that causes release builds to fail
+    if (gradle.startParameter.taskNames.contains("assembleRelease")) {
+        gradle.startParameter.excludedTaskNames += ":demo:lintVitalRelease"
+    }
+
     compileSdkVersion 29
     buildToolsVersion '30.0.2'
     //ndkVersion '20.0.5594570'

--- a/android/envoy/build.gradle
+++ b/android/envoy/build.gradle
@@ -57,7 +57,8 @@ dependencies {
     implementation 'org.greatfire.envoy:cronet:102.0.5005.195'
     implementation 'org.greatfire:IEnvoyProxy:1.2.1'
 
-    // api(name: 'cronet-debug', ext: 'aar')
+    // debugApi(name: 'cronet-debug', ext: 'aar')
+    // releaseApi(name: 'cronet-release', ext: 'aar')
 }
 
 def stdout = new ByteArrayOutputStream()


### PR DESCRIPTION
 - the sdkmanager path change resolved this error:
```
 Exception in thread "main" java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema
        at [com.android](http://com.android/).repository.api.SchemaModule$SchemaModuleVersion.<init>([SchemaModule.java:156](http://schemamodule.java:156/))
        at [com.android](http://com.android/).repository.api.SchemaModule.<init>([SchemaModule.java:75](http://schemamodule.java:75/))
        at [com.android](http://com.android/).sdklib.repository.AndroidSdkHandler.<clinit>([AndroidSdkHandler.java:81](http://androidsdkhandler.java:81/))
        at [com.android](http://com.android/).sdklib.tool.sdkmanager.SdkManagerCli.main([SdkManagerCli.java:73](http://sdkmanagercli.java:73/))
        at [com.android](http://com.android/).sdklib.tool.sdkmanager.SdkManagerCli.main([SdkManagerCli.java:48](http://sdkmanagercli.java:48/))
```
when searching for a solution it sounded as though newer versions of the sdkmanager were relocated to this path

 - the debugApi/releaseApi change resolved a problem where all builds used cronet-debug.aar

 - the additional file copies resolved this error:
```
 * What went wrong:
Could not determine the dependencies of task ':demo:lintVitalRelease'.
> Could not resolve all artifacts for configuration ':demo:debugCompileClasspath'.
   > Could not find :cronet-debug:.
     Required by:
         project :demo
         project :demo > project :envoy
```
it's not clear to me why lint is checking debug dependencies when doing a release build, but i wasn't able to find a way to prevent it.  it does not check release dependencies when doing a debug build.