### PR TITLE
check the directory exists before trying to remove it

### DIFF
--- a/native/build_cronet.sh
+++ b/native/build_cronet.sh
@@ -34,7 +34,9 @@ autoninja -C out/Cronet-Desktop cronet # cronet_sample
 for arch in arm arm64 x86 x64; do
     # arm_use_neon = false
     out_dir="$CHROMIUM_SRC_ROOT/out/Cronet-$arch-$BUILD_VARIANT"
-    rm -r "${out_dir}/cronet"
+    if [[ -d "${out_dir}/cronet" ]]; then
+        rm -r "${out_dir}/cronet"
+    fi
     gn_args="--out_dir=$out_dir"
     if [[ $BUILD_VARIANT == release ]]; then
         gn_args="$gn_args --release"


### PR DESCRIPTION
oops, the build errors out if the `cronet` directory it's trying to remove doesn't exist