### PR TITLE
update deps to 102.0.5005.195-1

### DIFF
--- a/android/demo/build.gradle
+++ b/android/demo/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation 'com.android.volley:volley:1.2.1'
 
     implementation project(path: ':envoy')
-    implementation 'org.greatfire.envoy:cronet:102.0.5005.195'
+    implementation 'org.greatfire.envoy:cronet:102.0.5005.195-1'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'

--- a/android/envoy/build.gradle
+++ b/android/envoy/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.preference:preference-ktx:1.1.1'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
-    implementation 'org.greatfire.envoy:cronet:102.0.5005.195'
+    implementation 'org.greatfire.envoy:cronet:102.0.5005.195-1'
     implementation 'org.greatfire:IEnvoyProxy:1.2.1'
 
     // debugApi(name: 'cronet-debug', ext: 'aar')


### PR DESCRIPTION
Cronet 102.0.5005.195-1 is being released on Maven, which enables the `envoy://` protocol and includes the updated Shadowsocks libsslocal.so's from https://github.com/gfw-report/shadowsocks-rust/releases

@mnbogner there's not anything else we need to update for the `envoy://` protocol or the updated Shadowsocks, is there?