### PR TITLE
revert a change to the sdkmanager path that breaks the build script

### DIFF
--- a/android/build-envoy.sh
+++ b/android/build-envoy.sh
@@ -16,7 +16,7 @@ export CMAKE_VERSION="3.10.2.4988404"
 export ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT:-$PWD/android-sdk-linux}
 export CMAKE_HOME=$ANDROID_SDK_ROOT/cmake/${CMAKE_VERSION}/bin
 export PATH=$PATH:$ANDROID_SDK_ROOT/platform-tools:$CMAKE_HOME
-export sdkmanager=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager
+export sdkmanager=$ANDROID_SDK_ROOT/tools/bin/sdkmanager
 
 set -euo pipefail
 if [ ! -e $sdkmanager ]; then


### PR DESCRIPTION
I don't know why this change was made (https://github.com/greatfire/envoy/commit/f1c5e4e0a75e3c72f4abefdb98625c1a253b647f), but it breaks the build-envoy.sh script. This PR reverts the change

Maybe it's a problem with the build system, but nothing exists in `$ANDROID_SDK_ROOT/cmdline-tools/` which causes it to download a version of android-sdk.zip and errors out when trying to overwrite what already exists in `$ANDROID_SDK_ROOT`