### PR TITLE
support envoy and ss urls

### DIFF
--- a/android/demo/build.gradle
+++ b/android/demo/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation 'com.android.volley:volley:1.2.1'
 
     implementation project(path: ':envoy')
-    implementation 'org.greatfire.envoy:cronet:102.0.5005.195-1'
+    implementation 'org.greatfire.envoy:cronet:102.0.5005.195-3'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'

--- a/android/envoy/build.gradle
+++ b/android/envoy/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.preference:preference-ktx:1.1.1'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
-    implementation 'org.greatfire.envoy:cronet:102.0.5005.195-1'
+    implementation 'org.greatfire.envoy:cronet:102.0.5005.195-3'
     implementation 'org.greatfire:IEnvoyProxy:1.2.1'
 
     // debugApi(name: 'cronet-debug', ext: 'aar')

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/NetworkIntentService.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/NetworkIntentService.kt
@@ -125,7 +125,7 @@ class NetworkIntentService : IntentService("NetworkIntentService") {
     private val cronetMap = Collections.synchronizedMap(mutableMapOf<String, CronetEngine>())
 
     private val httpPrefixes = Collections.synchronizedList(mutableListOf<String>("https", "http", "envoy"))
-    private val supportedPrefixes = Collections.synchronizedList(mutableListOf<String>("v2ws", "v2srtp", "v2wechat", "hysteria"))
+    private val supportedPrefixes = Collections.synchronizedList(mutableListOf<String>("v2ws", "v2srtp", "v2wechat", "hysteria", "ss"))
 
     inner class NetworkBinder : Binder() {
         // Return this instance of LocalService so clients can call public methods

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/NetworkIntentService.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/NetworkIntentService.kt
@@ -121,6 +121,9 @@ class NetworkIntentService : IntentService("NetworkIntentService") {
     private val cacheMap = Collections.synchronizedMap(mutableMapOf<String, String>())
     private val cronetMap = Collections.synchronizedMap(mutableMapOf<String, CronetEngine>())
 
+    private val httpPrefixes = Collections.synchronizedList(mutableListOf<String>("https", "http", "envoy"))
+    private val supportedPrefixes = Collections.synchronizedList(mutableListOf<String>("v2ws", "v2srtp", "v2wechat", "hysteria"))
+
     inner class NetworkBinder : Binder() {
         // Return this instance of LocalService so clients can call public methods
         fun getService(): NetworkIntentService = this@NetworkIntentService
@@ -213,12 +216,16 @@ class NetworkIntentService : IntentService("NetworkIntentService") {
             }
         } else {
             urlsToSubmit.forEach() { url ->
+                val parts = url.split(":")
+                val prefix = parts[0]
                 if (url.contains("test")) {
                     // no-op
-                } else if (url.startsWith("http")) {
+                } else if (httpPrefixes.contains(prefix)) {
                     shuffledHttps.add(url)
-                } else {
+                } else if (supportedPrefixes.contains(prefix)) {
                     shuffledUrls.add(url)
+                } else {
+                    Log.w(TAG, "found url with unsupported prefix: " + prefix)
                 }
             }
             Log.d(TAG, "shuffle " + (shuffledHttps.size + shuffledUrls.size) + " submitted urls")
@@ -321,9 +328,12 @@ class NetworkIntentService : IntentService("NetworkIntentService") {
             } else if (envoyUrl.startsWith("ss://")) {
                 Log.d(TAG, "found ss url: " + envoyUrl)
                 handleShadowsocksSubmit(envoyUrl, captive_portal_url, hysteriaCert, dnsttConfig, dnsttUrls)
-            } else {
-                Log.d(TAG, "found (https?) url: " + envoyUrl)
+            } else if (envoyUrl.startsWith("http") || envoyUrl.startsWith("envoy")) {
+                Log.d(TAG, "found http/envoy url: " + envoyUrl)
                 handleHttpsSubmit(envoyUrl, captive_portal_url, hysteriaCert, dnsttConfig, dnsttUrls)
+            } else {
+                // prefix check should handle this but if not, batch count may not add up
+                Log.w(TAG, "found unsupported url: " + envoyUrl)
             }
         }
 


### PR DESCRIPTION
 - updated the cronet dependencies to improve shadowsocks support
 - incoming urls are now compared against a list of specific supported prefixes that includes envoy and ss