### PR TITLE
Update to IEnvoyProxy 1.3.1

### DIFF
--- a/android/envoy/build.gradle
+++ b/android/envoy/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation 'androidx.preference:preference-ktx:1.1.1'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation 'org.greatfire.envoy:cronet:102.0.5005.195-4'
-    implementation 'org.greatfire:IEnvoyProxy:1.2.1'
+    implementation 'org.greatfire:IEnvoyProxy:1.3.1'
 
     // debugApi(name: 'cronet-debug', ext: 'aar')
     // releaseApi(name: 'cronet-release', ext: 'aar')


### PR DESCRIPTION
This version of IEnvoyProxy addresses the insecure temp file issues (though that code wasn't used, so it wasn't a real vuln). It also disables unused obfs4 support to slim down the build