### PR TITLE
manually added dependencies to pom file

### DIFF
--- a/android/envoy/build.gradle
+++ b/android/envoy/build.gradle
@@ -97,22 +97,22 @@ task writeNewPom {
     pom {
         project {
             name 'Envoy'
-	    packaging 'aar'
+            packaging 'aar'
             artifactId 'envoy'
             inceptionYear '2018'
             url 'https://github.com/greatfire/envoy'
-	    description 'C and Java Library derived from Chromium cronet'
+            description 'C and Java Library derived from Chromium cronet'
             licenses {
                 license {
                     name 'The Apache Software License, Version 2.0'
                     url 'https://github.com/greatfire/envoy/blob/master/LICENSE'
                     distribution 'repo'
                 }
-		license {
-		    name 'BSD-3-clause'
-		    url 'https://chromium.googlesource.com/chromium/src/+/refs/heads/main/LICENSE'
-		    distribution 'repo'
-		}
+                license {
+                    name 'BSD-3-clause'
+                    url 'https://chromium.googlesource.com/chromium/src/+/refs/heads/main/LICENSE'
+                    distribution 'repo'
+                }
             }
             developers {
                 developer {
@@ -128,11 +128,23 @@ task writeNewPom {
             }
             issueManagement {
                 url = "https://github.com/greatfire/envoy/issues"
-		system = "GitHub"
+                system = "GitHub"
             }
             scm {
                 connection = 'scm:git:https://github.com/greatfire/envoy.git'
                 url = 'https://github.com/greatfire/envoy'
+            }
+            dependencies {
+                dependency {
+                    groupId = 'org.greatfire.envoy'
+                    artifactId = 'cronet'
+                    version = '102.0.5005.195-4'
+                }
+                dependency {
+                    groupId = 'org.greatfire'
+                    artifactId = 'IEnvoyProxy'
+                    version = '1.3.1'
+                }
             }
         }
     }.writeTo(project.getBuildDir().toString() + "/outputs/aar/" + "envoy" + "-" + project.version + ".pom")


### PR DESCRIPTION
Projects including Envoy must include a dependency for IEnvoyProxy even if it is not referenced directly.  After some research it seems like the problem may be that the pom file published to Maven for Envoy does not list any dependencies.  These dependencies should be included automatically but since they are not, I manually added them for Cronet and IEnvoyProxy.  I also cleaned up the indentation in that section of the gradle file for clarity.