### PR TITLE
107.0.5304.150 envoy socks

### DIFF
--- a/native/0001-Envoy.patch
+++ b/native/0001-Envoy.patch
@@ -1,13 +1,9 @@
  chrome/browser/ssl/ssl_config_service_manager.cc   | 11 +++++
- components/cronet/android/api.txt                  |  4 +-
  .../api/src/org/chromium/net/CronetEngine.java     |  5 ++
  .../src/org/chromium/net/ICronetEngineBuilder.java |  1 +
  .../cronet/android/cronet_context_adapter.cc       |  2 +
- .../cronet/android/implementation_api_version.txt  |  2 +-
- .../cronet/android/interface_api_version.txt       |  2 +-
  .../chromium/net/impl/CronetEngineBuilderImpl.java | 11 +++++
  .../chromium/net/impl/CronetUrlRequestContext.java | 10 ++--
- .../org/chromium/net/impl/JavaCronetEngine.java    |  1 +
  .../cronet_sample_apk/CronetSampleActivity.java    |  1 +
  components/cronet/native/cronet.idl                |  1 +
  components/cronet/native/engine.cc                 |  1 +
@@ -16,20 +12,20 @@
  .../native/generated/cronet.idl_impl_struct.h      |  1 +
  .../generated/cronet.idl_impl_struct_unittest.cc   |  4 ++
  components/cronet/native/sample/main.cc            | 24 ++++++++++
- components/cronet/url_request_context_config.cc    | 49 +++++++++++++++++--
- components/cronet/url_request_context_config.h     | 42 ++++++++++++++++
+ components/cronet/url_request_context_config.cc    | 48 +++++++++++++++++--
+ components/cronet/url_request_context_config.h     | 42 +++++++++++++++++
  net/socket/client_socket_pool_manager.cc           |  2 +-
  net/spdy/spdy_http_utils.cc                        |  5 ++
  net/ssl/ssl_config_service_defaults.cc             |  4 ++
  net/ssl/ssl_config_service_defaults.h              |  1 +
  net/url_request/url_request_context.h              |  4 ++
- net/url_request/url_request_context_builder.cc     | 56 ++++++++++++++++++++--
+ net/url_request/url_request_context_builder.cc     | 55 ++++++++++++++++++++--
  net/url_request/url_request_context_builder.h      |  2 +
  net/url_request/url_request_http_job.cc            | 43 +++++++++++++++++
- 28 files changed, 292 insertions(+), 15 deletions(-)
+ 24 files changed, 284 insertions(+), 12 deletions(-)
 
 diff --git a/chrome/browser/ssl/ssl_config_service_manager.cc b/chrome/browser/ssl/ssl_config_service_manager.cc
-index 08fe7667d9ae9..ad013cae172cf 100644
+index 6537a65ed4cd3..66cf928be46cb 100644
 --- a/chrome/browser/ssl/ssl_config_service_manager.cc
 +++ b/chrome/browser/ssl/ssl_config_service_manager.cc
 @@ -13,6 +13,7 @@
@@ -48,7 +44,7 @@ index 08fe7667d9ae9..ad013cae172cf 100644
  #include "net/cert/cert_verifier.h"
  #include "net/ssl/ssl_cipher_suite_names.h"
  #include "net/ssl/ssl_config_service.h"
-@@ -172,6 +174,7 @@ void SSLConfigServiceManager::RegisterPrefs(PrefRegistrySimple* registry) {
+@@ -177,6 +179,7 @@ void SSLConfigServiceManager::RegisterPrefs(PrefRegistrySimple* registry) {
  
  void SSLConfigServiceManager::AddToNetworkContextParams(
      network::mojom::NetworkContextParams* network_context_params) {
@@ -56,10 +52,10 @@ index 08fe7667d9ae9..ad013cae172cf 100644
    network_context_params->initial_ssl_config = GetSSLConfigFromPrefs();
    mojo::Remote<network::mojom::SSLConfigClient> ssl_config_client;
    network_context_params->ssl_config_client_receiver =
-@@ -244,6 +247,14 @@ void SSLConfigServiceManager::OnDisabledCipherSuitesChange(
-   const base::ListValue* value = &base::Value::AsListValue(
-       *local_state->GetList(prefs::kCipherSuiteBlacklist));
-   disabled_cipher_suites_ = ParseCipherSuites(ListValueToStringVector(value));
+@@ -250,6 +253,14 @@ void SSLConfigServiceManager::OnDisabledCipherSuitesChange(
+   const base::Value::List& list =
+       local_state->GetList(prefs::kCipherSuiteBlacklist);
+   disabled_cipher_suites_ = ParseCipherSuites(ValueListToStringVector(list));
 +
 +  auto envoy_url = GURL(local_state->GetString(prefs::kEnvoyUrl));
 +  std::string disabled_cipher_suites;
@@ -71,34 +67,8 @@ index 08fe7667d9ae9..ad013cae172cf 100644
  }
  
  void SSLConfigServiceManager::CacheVariationsPolicy(PrefService* local_state) {
-diff --git a/components/cronet/android/api.txt b/components/cronet/android/api.txt
-index 730e51520ee2d..cc19e7d3317fc 100644
---- a/components/cronet/android/api.txt
-+++ b/components/cronet/android/api.txt
-@@ -57,6 +57,7 @@ public class org.chromium.net.CronetEngine$Builder {
-   public org.chromium.net.CronetEngine$Builder(org.chromium.net.ICronetEngineBuilder);
-   public java.lang.String getDefaultUserAgent();
-   public org.chromium.net.CronetEngine$Builder setUserAgent(java.lang.String);
-+  public org.chromium.net.CronetEngine$Builder setEnvoyUrl(java.lang.String);
-   public org.chromium.net.CronetEngine$Builder setStoragePath(java.lang.String);
-   public org.chromium.net.CronetEngine$Builder setLibraryLoader(org.chromium.net.CronetEngine$Builder$LibraryLoader);
-   public org.chromium.net.CronetEngine$Builder enableQuic(boolean);
-@@ -217,6 +218,7 @@ public abstract class org.chromium.net.ICronetEngineBuilder {
-   public abstract org.chromium.net.ICronetEngineBuilder setStoragePath(java.lang.String);
-   public abstract org.chromium.net.ICronetEngineBuilder setUserAgent(java.lang.String);
-   public abstract java.lang.String getDefaultUserAgent();
-+  public abstract org.chromium.net.ICronetEngineBuilder setEnvoyUrl(java.lang.String);
-   public abstract org.chromium.net.ExperimentalCronetEngine build();
-   public org.chromium.net.ICronetEngineBuilder enableNetworkQualityEstimator(boolean);
-   public org.chromium.net.ICronetEngineBuilder setThreadPriority(int);
-@@ -401,4 +403,4 @@ public abstract class org.chromium.net.UrlResponseInfo {
-   public abstract java.lang.String getProxyServer();
-   public abstract long getReceivedByteCount();
- }
--Stamp: c760ed0e85d0a71dd2dfa3a34bfbbd08
-+Stamp: bffce221f97cb5b4511b1058a20d82e2
 diff --git a/components/cronet/android/api/src/org/chromium/net/CronetEngine.java b/components/cronet/android/api/src/org/chromium/net/CronetEngine.java
-index b7720524560d1..cf7a6c385349f 100644
+index 9941d67bbd97a..af658b248e122 100644
 --- a/components/cronet/android/api/src/org/chromium/net/CronetEngine.java
 +++ b/components/cronet/android/api/src/org/chromium/net/CronetEngine.java
 @@ -113,6 +113,11 @@ public abstract class CronetEngine {
@@ -114,7 +84,7 @@ index b7720524560d1..cf7a6c385349f 100644
           * Sets directory for HTTP Cache and Cookie Storage. The directory must
           * exist.
 diff --git a/components/cronet/android/api/src/org/chromium/net/ICronetEngineBuilder.java b/components/cronet/android/api/src/org/chromium/net/ICronetEngineBuilder.java
-index 1f6694d4cc7bd..9a9bcb4940e05 100644
+index 4cdb0bf790198..e645c8218dfc8 100644
 --- a/components/cronet/android/api/src/org/chromium/net/ICronetEngineBuilder.java
 +++ b/components/cronet/android/api/src/org/chromium/net/ICronetEngineBuilder.java
 @@ -36,6 +36,7 @@ public abstract class ICronetEngineBuilder {
@@ -126,10 +96,10 @@ index 1f6694d4cc7bd..9a9bcb4940e05 100644
  
      // Experimental API methods.
 diff --git a/components/cronet/android/cronet_context_adapter.cc b/components/cronet/android/cronet_context_adapter.cc
-index 9fa90f00a8ff7..bef24dc7872ac 100644
+index 8ae0e429e185e..99fc5f16ae2ac 100644
 --- a/components/cronet/android/cronet_context_adapter.cc
 +++ b/components/cronet/android/cronet_context_adapter.cc
-@@ -238,6 +238,7 @@ int CronetContextAdapter::default_load_flags() const {
+@@ -243,6 +243,7 @@ int CronetContextAdapter::default_load_flags() const {
  static jlong JNI_CronetUrlRequestContext_CreateRequestContextConfig(
      JNIEnv* env,
      const JavaParamRef<jstring>& juser_agent,
@@ -137,7 +107,7 @@ index 9fa90f00a8ff7..bef24dc7872ac 100644
      const JavaParamRef<jstring>& jstorage_path,
      jboolean jquic_enabled,
      const JavaParamRef<jstring>& jquic_default_user_agent_id,
-@@ -261,6 +262,7 @@ static jlong JNI_CronetUrlRequestContext_CreateRequestContextConfig(
+@@ -266,6 +267,7 @@ static jlong JNI_CronetUrlRequestContext_CreateRequestContextConfig(
            ConvertNullableJavaStringToUTF8(env, jstorage_path),
            /* accept_languages */ std::string(),
            ConvertNullableJavaStringToUTF8(env, juser_agent),
@@ -145,25 +115,11 @@ index 9fa90f00a8ff7..bef24dc7872ac 100644
            ConvertNullableJavaStringToUTF8(
                env, jexperimental_quic_connection_options),
            base::WrapUnique(
-diff --git a/components/cronet/android/implementation_api_version.txt b/components/cronet/android/implementation_api_version.txt
-index 60d3b2f4a4cd5..b6a7d89c68e0c 100644
---- a/components/cronet/android/implementation_api_version.txt
-+++ b/components/cronet/android/implementation_api_version.txt
-@@ -1 +1 @@
--15
-+16
-diff --git a/components/cronet/android/interface_api_version.txt b/components/cronet/android/interface_api_version.txt
-index 60d3b2f4a4cd5..b6a7d89c68e0c 100644
---- a/components/cronet/android/interface_api_version.txt
-+++ b/components/cronet/android/interface_api_version.txt
-@@ -1 +1 @@
--15
-+16
 diff --git a/components/cronet/android/java/src/org/chromium/net/impl/CronetEngineBuilderImpl.java b/components/cronet/android/java/src/org/chromium/net/impl/CronetEngineBuilderImpl.java
-index 586963dfa40b2..860e2cbe5e709 100644
+index bb406f41cd9f1..f5647db0643ec 100644
 --- a/components/cronet/android/java/src/org/chromium/net/impl/CronetEngineBuilderImpl.java
 +++ b/components/cronet/android/java/src/org/chromium/net/impl/CronetEngineBuilderImpl.java
-@@ -80,6 +80,7 @@ public abstract class CronetEngineBuilderImpl extends ICronetEngineBuilder {
+@@ -139,6 +139,7 @@ public abstract class CronetEngineBuilderImpl extends ICronetEngineBuilder {
      private final List<Pkp> mPkps = new LinkedList<>();
      private boolean mPublicKeyPinningBypassForLocalTrustAnchorsEnabled;
      private String mUserAgent;
@@ -171,7 +127,7 @@ index 586963dfa40b2..860e2cbe5e709 100644
      private String mStoragePath;
      private boolean mQuicEnabled;
      private boolean mHttp2Enabled;
-@@ -121,6 +122,16 @@ public abstract class CronetEngineBuilderImpl extends ICronetEngineBuilder {
+@@ -181,6 +182,16 @@ public abstract class CronetEngineBuilderImpl extends ICronetEngineBuilder {
          return mUserAgent;
      }
  
@@ -189,10 +145,10 @@ index 586963dfa40b2..860e2cbe5e709 100644
      public CronetEngineBuilderImpl setStoragePath(String value) {
          if (!new File(value).isDirectory()) {
 diff --git a/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java b/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java
-index e5f557a65f336..8e2f755183fe8 100644
+index e4c2df648b454..0ac80eb23964c 100644
 --- a/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java
 +++ b/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java
-@@ -208,7 +208,7 @@ public class CronetUrlRequestContext extends CronetEngineBase {
+@@ -249,7 +249,7 @@ public class CronetUrlRequestContext extends CronetEngineBase {
      public static long createNativeUrlRequestContextConfig(CronetEngineBuilderImpl builder) {
          final long urlRequestContextConfig =
                  CronetUrlRequestContextJni.get().createRequestContextConfig(builder.getUserAgent(),
@@ -201,7 +157,7 @@ index e5f557a65f336..8e2f755183fe8 100644
                          builder.getDefaultQuicUserAgentId(), builder.http2Enabled(),
                          builder.brotliEnabled(), builder.cacheDisabled(), builder.httpCacheMode(),
                          builder.httpCacheMaxSize(), builder.experimentalOptions(),
-@@ -735,10 +735,10 @@ public class CronetUrlRequestContext extends CronetEngineBase {
+@@ -785,10 +785,10 @@ public class CronetUrlRequestContext extends CronetEngineBase {
      // Native methods are implemented in cronet_url_request_context_adapter.cc.
      @NativeMethods
      interface Natives {
@@ -216,20 +172,8 @@ index e5f557a65f336..8e2f755183fe8 100644
                  boolean enableNetworkQualityEstimator,
                  boolean bypassPublicKeyPinningForLocalTrustAnchors, int networkThreadPriority);
  
-diff --git a/components/cronet/android/java/src/org/chromium/net/impl/JavaCronetEngine.java b/components/cronet/android/java/src/org/chromium/net/impl/JavaCronetEngine.java
-index 8bdd6f013ae14..e472c24d3c720 100644
---- a/components/cronet/android/java/src/org/chromium/net/impl/JavaCronetEngine.java
-+++ b/components/cronet/android/java/src/org/chromium/net/impl/JavaCronetEngine.java
-@@ -81,6 +81,7 @@ public final class JavaCronetEngine extends CronetEngineBase {
-                     "The multi-network API is not supported by the Java implementation "
-                     + "of Cronet Engine");
-         }
-+        // TODO add mEnvoyUrl
-         return new JavaUrlRequest(callback, mExecutorService, executor, url, mUserAgent,
-                 allowDirectExecutor, trafficStatsTagSet, trafficStatsTag, trafficStatsUidSet,
-                 trafficStatsUid);
 diff --git a/components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleActivity.java b/components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleActivity.java
-index 0d72426a568a6..1ff0b8f2433ec 100644
+index 5d3a93c519b2b..9538b5072539a 100644
 --- a/components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleActivity.java
 +++ b/components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleActivity.java
 @@ -125,6 +125,7 @@ public class CronetSampleActivity extends Activity {
@@ -241,7 +185,7 @@ index 0d72426a568a6..1ff0b8f2433ec 100644
  
          mCronetEngine = myBuilder.build();
 diff --git a/components/cronet/native/cronet.idl b/components/cronet/native/cronet.idl
-index f0be146362360..85b9547085b1d 100644
+index ddb3ad5b3b705..0bdf3ef4059b0 100644
 --- a/components/cronet/native/cronet.idl
 +++ b/components/cronet/native/cronet.idl
 @@ -510,6 +510,7 @@ struct EngineParams {
@@ -253,7 +197,7 @@ index f0be146362360..85b9547085b1d 100644
    /**
     * Sets a default value for the Accept-Language header value for UrlRequests
 diff --git a/components/cronet/native/engine.cc b/components/cronet/native/engine.cc
-index 8c110870a0c4f..41394fda40683 100644
+index 6f27d1a6d0059..d6ea7f8c8e3e0 100644
 --- a/components/cronet/native/engine.cc
 +++ b/components/cronet/native/engine.cc
 @@ -149,6 +149,7 @@ Cronet_RESULT Cronet_EngineImpl::StartWithParams(
@@ -265,7 +209,7 @@ index 8c110870a0c4f..41394fda40683 100644
    context_config_builder.bypass_public_key_pinning_for_local_trust_anchors =
        params->enable_public_key_pinning_bypass_for_local_trust_anchors;
 diff --git a/components/cronet/native/generated/cronet.idl_c.h b/components/cronet/native/generated/cronet.idl_c.h
-index 041fd8f58813d..749938a50780f 100644
+index 988e6efacb0f3..b00b185572ef1 100644
 --- a/components/cronet/native/generated/cronet.idl_c.h
 +++ b/components/cronet/native/generated/cronet.idl_c.h
 @@ -795,6 +795,9 @@ CRONET_EXPORT
@@ -289,7 +233,7 @@ index 041fd8f58813d..749938a50780f 100644
      const Cronet_EngineParamsPtr self);
  CRONET_EXPORT
 diff --git a/components/cronet/native/generated/cronet.idl_impl_struct.cc b/components/cronet/native/generated/cronet.idl_impl_struct.cc
-index 9ff9bc81ccb26..a7767ff223ee3 100644
+index 61667e399148b..abb6dd92c71db 100644
 --- a/components/cronet/native/generated/cronet.idl_impl_struct.cc
 +++ b/components/cronet/native/generated/cronet.idl_impl_struct.cc
 @@ -249,6 +249,12 @@ void Cronet_EngineParams_user_agent_set(Cronet_EngineParamsPtr self,
@@ -319,7 +263,7 @@ index 9ff9bc81ccb26..a7767ff223ee3 100644
      const Cronet_EngineParamsPtr self) {
    DCHECK(self);
 diff --git a/components/cronet/native/generated/cronet.idl_impl_struct.h b/components/cronet/native/generated/cronet.idl_impl_struct.h
-index 84d6db6c3cfd1..592cae0e3efa1 100644
+index a665b85ac93cb..95841a7e18296 100644
 --- a/components/cronet/native/generated/cronet.idl_impl_struct.h
 +++ b/components/cronet/native/generated/cronet.idl_impl_struct.h
 @@ -83,6 +83,7 @@ struct Cronet_EngineParams {
@@ -331,7 +275,7 @@ index 84d6db6c3cfd1..592cae0e3efa1 100644
    std::string storage_path;
    bool enable_quic = true;
 diff --git a/components/cronet/native/generated/cronet.idl_impl_struct_unittest.cc b/components/cronet/native/generated/cronet.idl_impl_struct_unittest.cc
-index 06f48ee97b4e1..4bc6c6d6223df 100644
+index 11991a5a9ba48..9a2c19a8f8624 100644
 --- a/components/cronet/native/generated/cronet.idl_impl_struct_unittest.cc
 +++ b/components/cronet/native/generated/cronet.idl_impl_struct_unittest.cc
 @@ -107,6 +107,10 @@ TEST_F(CronetStructTest, TestCronet_EngineParams) {
@@ -346,7 +290,7 @@ index 06f48ee97b4e1..4bc6c6d6223df 100644
        second, Cronet_EngineParams_accept_language_get(first));
    EXPECT_STREQ(Cronet_EngineParams_accept_language_get(first),
 diff --git a/components/cronet/native/sample/main.cc b/components/cronet/native/sample/main.cc
-index fb2272e713711..7b21245fdb8aa 100644
+index 0cbbdce569e14..f69f8e5d3cd49 100644
 --- a/components/cronet/native/sample/main.cc
 +++ b/components/cronet/native/sample/main.cc
 @@ -12,6 +12,30 @@ Cronet_EnginePtr CreateCronetEngine() {
@@ -381,10 +325,10 @@ index fb2272e713711..7b21245fdb8aa 100644
  
    Cronet_Engine_StartWithParams(cronet_engine, engine_params);
 diff --git a/components/cronet/url_request_context_config.cc b/components/cronet/url_request_context_config.cc
-index a5688c7f2bf9d..a16f9469dce6b 100644
+index b03411758c0d7..775e51eedc781 100644
 --- a/components/cronet/url_request_context_config.cc
 +++ b/components/cronet/url_request_context_config.cc
-@@ -263,6 +263,47 @@ URLRequestContextConfig::PreloadedNelAndReportingHeader::
+@@ -276,6 +276,46 @@ URLRequestContextConfig::PreloadedNelAndReportingHeader::
  URLRequestContextConfig::PreloadedNelAndReportingHeader::
      ~PreloadedNelAndReportingHeader() = default;
  
@@ -400,7 +344,7 @@ index a5688c7f2bf9d..a16f9469dce6b 100644
 +    const std::string& accept_language,
 +    const std::string& user_agent,
 +    const std::string& envoy_url,
-+    base::Value::DictStorage experimental_options,
++    base::Value::Dict experimental_options,
 +    std::unique_ptr<net::CertVerifier> mock_cert_verifier,
 +    bool enable_network_quality_estimator,
 +    bool bypass_public_key_pinning_for_local_trust_anchors,
@@ -420,8 +364,7 @@ index a5688c7f2bf9d..a16f9469dce6b 100644
 +      enable_network_quality_estimator(enable_network_quality_estimator),
 +      bypass_public_key_pinning_for_local_trust_anchors(
 +          bypass_public_key_pinning_for_local_trust_anchors),
-+      effective_experimental_options(
-+          base::Value(experimental_options).TakeDictDeprecated()),
++      effective_experimental_options(experimental_options.Clone()),
 +      experimental_options(std::move(experimental_options)),
 +      network_thread_priority(network_thread_priority),
 +      bidi_stream_detect_broken_connection(false),
@@ -432,7 +375,7 @@ index a5688c7f2bf9d..a16f9469dce6b 100644
  URLRequestContextConfig::URLRequestContextConfig(
      bool enable_quic,
      const std::string& quic_user_agent_id,
-@@ -317,6 +358,7 @@ URLRequestContextConfig::CreateURLRequestContextConfig(
+@@ -330,6 +370,7 @@ URLRequestContextConfig::CreateURLRequestContextConfig(
      const std::string& storage_path,
      const std::string& accept_language,
      const std::string& user_agent,
@@ -440,16 +383,16 @@ index a5688c7f2bf9d..a16f9469dce6b 100644
      const std::string& unparsed_experimental_options,
      std::unique_ptr<net::CertVerifier> mock_cert_verifier,
      bool enable_network_quality_estimator,
-@@ -335,7 +377,7 @@ URLRequestContextConfig::CreateURLRequestContextConfig(
+@@ -348,7 +389,7 @@ URLRequestContextConfig::CreateURLRequestContextConfig(
    return base::WrapUnique(new URLRequestContextConfig(
        enable_quic, quic_user_agent_id, enable_spdy, enable_brotli, http_cache,
        http_cache_max_size, load_disable_cache, storage_path, accept_language,
--      user_agent, std::move(experimental_options.value()),
-+      user_agent, envoy_url, std::move(experimental_options.value()),
+-      user_agent, std::move(experimental_options).value(),
++      user_agent, envoy_url, std::move(experimental_options).value(),
        std::move(mock_cert_verifier), enable_network_quality_estimator,
        bypass_public_key_pinning_for_local_trust_anchors,
        network_thread_priority));
-@@ -826,6 +868,7 @@ void URLRequestContextConfig::ConfigureURLRequestContextBuilder(
+@@ -871,6 +912,7 @@ void URLRequestContextConfig::ConfigureURLRequestContextBuilder(
    }
    context_builder->set_accept_language(accept_language);
    context_builder->set_user_agent(user_agent);
@@ -457,7 +400,7 @@ index a5688c7f2bf9d..a16f9469dce6b 100644
    net::HttpNetworkSessionParams session_params;
    session_params.enable_http2 = enable_spdy;
    session_params.enable_quic = enable_quic;
-@@ -861,8 +904,8 @@ URLRequestContextConfigBuilder::Build() {
+@@ -906,8 +948,8 @@ URLRequestContextConfigBuilder::Build() {
    return URLRequestContextConfig::CreateURLRequestContextConfig(
        enable_quic, quic_user_agent_id, enable_spdy, enable_brotli, http_cache,
        http_cache_max_size, load_disable_cache, storage_path, accept_language,
@@ -469,10 +412,10 @@ index a5688c7f2bf9d..a16f9469dce6b 100644
        network_thread_priority);
  }
 diff --git a/components/cronet/url_request_context_config.h b/components/cronet/url_request_context_config.h
-index 6537dcd491d82..e8b3440dbf7f9 100644
+index 6561e1ccec536..42e076ef83854 100644
 --- a/components/cronet/url_request_context_config.h
 +++ b/components/cronet/url_request_context_config.h
-@@ -127,6 +127,8 @@ struct URLRequestContextConfig {
+@@ -130,6 +130,8 @@ struct URLRequestContextConfig {
    // User-Agent request header field.
    const std::string user_agent;
  
@@ -481,7 +424,7 @@ index 6537dcd491d82..e8b3440dbf7f9 100644
    // Certificate verifier for testing.
    std::unique_ptr<net::CertVerifier> mock_cert_verifier;
  
-@@ -202,6 +204,7 @@ struct URLRequestContextConfig {
+@@ -208,6 +210,7 @@ struct URLRequestContextConfig {
        const std::string& accept_language,
        // User-Agent request header field.
        const std::string& user_agent,
@@ -489,7 +432,7 @@ index 6537dcd491d82..e8b3440dbf7f9 100644
        // JSON encoded experimental options.
        const std::string& unparsed_experimental_options,
        // MockCertVerifier to use for testing purposes.
-@@ -217,6 +220,44 @@ struct URLRequestContextConfig {
+@@ -223,6 +226,44 @@ struct URLRequestContextConfig {
        absl::optional<double> network_thread_priority);
  
   private:
@@ -518,7 +461,7 @@ index 6537dcd491d82..e8b3440dbf7f9 100644
 +      // Envoy URL
 +      const std::string& envoy_url,
 +      // Parsed experimental options.
-+      base::Value::DictStorage experimental_options,
++      base::Value::Dict experimental_options,
 +      // MockCertVerifier to use for testing purposes.
 +      std::unique_ptr<net::CertVerifier> mock_cert_verifier,
 +      // Enable network quality estimator.
@@ -534,7 +477,7 @@ index 6537dcd491d82..e8b3440dbf7f9 100644
    URLRequestContextConfig(
        // Enable QUIC.
        bool enable_quic,
-@@ -309,6 +350,7 @@ struct URLRequestContextConfigBuilder {
+@@ -316,6 +357,7 @@ struct URLRequestContextConfigBuilder {
    std::string accept_language = "";
    // User-Agent request header field.
    std::string user_agent = "";
@@ -543,7 +486,7 @@ index 6537dcd491d82..e8b3440dbf7f9 100644
    // experiments and their corresponding configuration options. The format
    // is a JSON object with the name of the experiment as the key, and the
 diff --git a/net/socket/client_socket_pool_manager.cc b/net/socket/client_socket_pool_manager.cc
-index b41e79eb1bfb6..f2172712c984c 100644
+index 521ebc8f5023e..9e5dbfa8c41e8 100644
 --- a/net/socket/client_socket_pool_manager.cc
 +++ b/net/socket/client_socket_pool_manager.cc
 @@ -48,7 +48,7 @@ static_assert(std::size(g_max_sockets_per_pool) ==
@@ -556,7 +499,7 @@ index b41e79eb1bfb6..f2172712c984c 100644
  };
  
 diff --git a/net/spdy/spdy_http_utils.cc b/net/spdy/spdy_http_utils.cc
-index 80ca0386e6328..7a299fa0ed2e9 100644
+index 59f0503786100..06c35d0e48a5b 100644
 --- a/net/spdy/spdy_http_utils.cc
 +++ b/net/spdy/spdy_http_utils.cc
 @@ -111,6 +111,11 @@ void CreateSpdyHeadersFromHttpRequest(const HttpRequestInfo& info,
@@ -572,7 +515,7 @@ index 80ca0386e6328..7a299fa0ed2e9 100644
          name == "proxy-connection" || name == "transfer-encoding" ||
          name == "host") {
 diff --git a/net/ssl/ssl_config_service_defaults.cc b/net/ssl/ssl_config_service_defaults.cc
-index 9348bb1648927..5fa9090f85cb1 100644
+index c48064549ced4..f2831cdb04ea1 100644
 --- a/net/ssl/ssl_config_service_defaults.cc
 +++ b/net/ssl/ssl_config_service_defaults.cc
 @@ -9,6 +9,10 @@ namespace net {
@@ -587,7 +530,7 @@ index 9348bb1648927..5fa9090f85cb1 100644
    return default_config_;
  }
 diff --git a/net/ssl/ssl_config_service_defaults.h b/net/ssl/ssl_config_service_defaults.h
-index c77a29140df77..5289c938b09c7 100644
+index 4bf47d05b527f..4cc06b182d624 100644
 --- a/net/ssl/ssl_config_service_defaults.h
 +++ b/net/ssl/ssl_config_service_defaults.h
 @@ -21,6 +21,7 @@ class NET_EXPORT SSLConfigServiceDefaults : public SSLConfigService {
@@ -599,12 +542,12 @@ index c77a29140df77..5289c938b09c7 100644
    // Returns the default SSL config settings.
    SSLContextConfig GetSSLContextConfig() override;
 diff --git a/net/url_request/url_request_context.h b/net/url_request/url_request_context.h
-index 27df35f3e4832..719e9f2c17a69 100644
+index 4ee83f194cbc3..f7370f0487ad5 100644
 --- a/net/url_request/url_request_context.h
 +++ b/net/url_request/url_request_context.h
-@@ -233,6 +233,9 @@ class NET_EXPORT URLRequestContext {
-     return bound_network_;
-   }
+@@ -231,6 +231,9 @@ class NET_EXPORT URLRequestContext final {
+   // context has been bound to.
+   handles::NetworkHandle bound_network() const { return bound_network_; }
  
 +  void set_envoy_url(const std::string& envoy_url) { envoy_url_ = envoy_url; }
 +  const std::string& envoy_url() const { return envoy_url_; }
@@ -612,16 +555,16 @@ index 27df35f3e4832..719e9f2c17a69 100644
    void AssertCalledOnValidThread() {
      DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
    }
-@@ -360,6 +363,7 @@ class NET_EXPORT URLRequestContext {
-   // Triggers a DCHECK if a NetworkIsolationKey/IsolationInfo is not provided to
-   // a request when true.
-   bool require_network_isolation_key_;
+@@ -359,6 +362,7 @@ class NET_EXPORT URLRequestContext final {
+   // Triggers a DCHECK if a NetworkAnonymizationKey/IsolationInfo is not
+   // provided to a request when true.
+   bool require_network_isolation_key_ = false;
 +  std::string envoy_url_;
  
-   NetworkChangeNotifier::NetworkHandle bound_network_;
+   handles::NetworkHandle bound_network_;
  
 diff --git a/net/url_request/url_request_context_builder.cc b/net/url_request/url_request_context_builder.cc
-index f3160569254a1..43bcee9811b6a 100644
+index 6ee8f97b02225..883d2e49dc032 100644
 --- a/net/url_request/url_request_context_builder.cc
 +++ b/net/url_request/url_request_context_builder.cc
 @@ -13,6 +13,7 @@
@@ -632,7 +575,7 @@ index f3160569254a1..43bcee9811b6a 100644
  #include "base/task/single_thread_task_runner.h"
  #include "base/task/thread_pool.h"
  #include "base/threading/thread_task_runner_handle.h"
-@@ -20,6 +21,7 @@
+@@ -21,6 +22,7 @@
  #include "net/base/cache_type.h"
  #include "net/base/net_errors.h"
  #include "net/base/network_delegate_impl.h"
@@ -640,7 +583,7 @@ index f3160569254a1..43bcee9811b6a 100644
  #include "net/cert/cert_verifier.h"
  #include "net/cert/ct_log_verifier.h"
  #include "net/cert/ct_policy_enforcer.h"
-@@ -30,6 +32,7 @@
+@@ -31,6 +33,7 @@
  #include "net/dns/context_host_resolver.h"
  #include "net/dns/host_resolver.h"
  #include "net/dns/host_resolver_manager.h"
@@ -648,7 +591,7 @@ index f3160569254a1..43bcee9811b6a 100644
  #include "net/http/http_auth_handler_factory.h"
  #include "net/http/http_cache.h"
  #include "net/http/http_network_layer.h"
-@@ -45,6 +48,7 @@
+@@ -46,6 +49,7 @@
  #include "net/quic/quic_context.h"
  #include "net/quic/quic_stream_factory.h"
  #include "net/socket/network_binding_client_socket_factory.h"
@@ -656,7 +599,7 @@ index f3160569254a1..43bcee9811b6a 100644
  #include "net/ssl/ssl_config_service_defaults.h"
  #include "net/url_request/static_http_user_agent_settings.h"
  #include "net/url_request/url_request_context.h"
-@@ -185,6 +189,10 @@ void URLRequestContextBuilder::set_user_agent(const std::string& user_agent) {
+@@ -125,6 +129,10 @@ void URLRequestContextBuilder::set_user_agent(const std::string& user_agent) {
    user_agent_ = user_agent;
  }
  
@@ -667,20 +610,20 @@ index f3160569254a1..43bcee9811b6a 100644
  void URLRequestContextBuilder::set_http_user_agent_settings(
      std::unique_ptr<HttpUserAgentSettings> http_user_agent_settings) {
    http_user_agent_settings_ = std::move(http_user_agent_settings);
-@@ -337,6 +345,8 @@ std::unique_ptr<URLRequestContext> URLRequestContextBuilder::Build() {
+@@ -278,6 +286,8 @@ std::unique_ptr<URLRequestContext> URLRequestContextBuilder::Build() {
    context->set_require_network_isolation_key(require_network_isolation_key_);
    context->set_network_quality_estimator(network_quality_estimator_);
  
 +  if (!envoy_url_.empty())
 +    context->set_envoy_url(envoy_url_);
    if (http_user_agent_settings_) {
-     storage->set_http_user_agent_settings(std::move(http_user_agent_settings_));
+     context->set_http_user_agent_settings(std::move(http_user_agent_settings_));
    } else {
-@@ -418,13 +428,53 @@ std::unique_ptr<URLRequestContext> URLRequestContextBuilder::Build() {
+@@ -363,13 +373,52 @@ std::unique_ptr<URLRequestContext> URLRequestContextBuilder::Build() {
      }
    }
    host_resolver_->SetRequestContext(context.get());
--  storage->set_host_resolver(std::move(host_resolver_));
+-  context->set_host_resolver(std::move(host_resolver_));
 +
 +  auto envoy_url = GURL(envoy_url_);
 +  std::string value;
@@ -692,22 +635,21 @@ index f3160569254a1..43bcee9811b6a 100644
 +    std::unique_ptr<net::MappedHostResolver> remapped_resolver(
 +        new net::MappedHostResolver(std::move(host_resolver_)));
 +    remapped_resolver->SetRulesFromString(value);
-+    storage->set_host_resolver(std::move(remapped_resolver));
++    context->set_host_resolver(std::move(remapped_resolver));
 +  } else if (GetValueForKeyInQuery(envoy_url, "address", &value)) {
 +    std::unique_ptr<net::MappedHostResolver> remapped_resolver(
 +        new net::MappedHostResolver(std::move(host_resolver_)));
 +    remapped_resolver->SetRulesFromString("MAP " + url.host() + " " + value);
-+    storage->set_host_resolver(std::move(remapped_resolver));
++    context->set_host_resolver(std::move(remapped_resolver));
 +  } else {
-+    storage->set_host_resolver(std::move(host_resolver_));
++    context->set_host_resolver(std::move(host_resolver_));
 +  }
  
    if (ssl_config_service_) {
-     storage->set_ssl_config_service(std::move(ssl_config_service_));
+     context->set_ssl_config_service(std::move(ssl_config_service_));
    } else {
--    storage->set_ssl_config_service(
+-    context->set_ssl_config_service(
 -        std::make_unique<SSLConfigServiceDefaults>());
-+
 +    SSLContextConfig ssl_context_config;
 +    std::vector<uint16_t> disabled_ciphers;
 +    if (GetValueForKeyInQuery(envoy_url, "disabled_cipher_suites", &value)) {
@@ -729,15 +671,15 @@ index f3160569254a1..43bcee9811b6a 100644
 +      ssl_context_config.disabled_cipher_suites =  cipher_suites;
 +    }
 +    auto ssl_config_service_ptr = std::make_unique<SSLConfigServiceDefaults>(ssl_context_config);
-+    storage->set_ssl_config_service(std::move(ssl_config_service_ptr));
++    context->set_ssl_config_service(std::move(ssl_config_service_ptr));
    }
  
    if (http_auth_handler_factory_) {
 diff --git a/net/url_request/url_request_context_builder.h b/net/url_request/url_request_context_builder.h
-index 7bdf93aeb7aa1..0ad42c07c1301 100644
+index d2220a6a86bf1..dd0c3bdd107dd 100644
 --- a/net/url_request/url_request_context_builder.h
 +++ b/net/url_request/url_request_context_builder.h
-@@ -188,6 +188,7 @@ class NET_EXPORT URLRequestContextBuilder {
+@@ -193,6 +193,7 @@ class NET_EXPORT URLRequestContextBuilder {
    // have the headers already set.
    void set_accept_language(const std::string& accept_language);
    void set_user_agent(const std::string& user_agent);
@@ -745,7 +687,7 @@ index 7bdf93aeb7aa1..0ad42c07c1301 100644
  
    // Makes the created URLRequestContext use a particular HttpUserAgentSettings
    // object. Not compatible with set_accept_language() / set_user_agent().
-@@ -395,6 +396,7 @@ class NET_EXPORT URLRequestContextBuilder {
+@@ -410,6 +411,7 @@ class NET_EXPORT URLRequestContextBuilder {
  
    std::string accept_language_;
    std::string user_agent_;
@@ -754,7 +696,7 @@ index 7bdf93aeb7aa1..0ad42c07c1301 100644
  
    bool http_cache_enabled_ = true;
 diff --git a/net/url_request/url_request_http_job.cc b/net/url_request/url_request_http_job.cc
-index 2db8e1bc9e5bb..6d538ec24b3f2 100644
+index 0878808a8dc72..b9b6212bc0d64 100644
 --- a/net/url_request/url_request_http_job.cc
 +++ b/net/url_request/url_request_http_job.cc
 @@ -18,6 +18,7 @@
@@ -766,10 +708,10 @@ index 2db8e1bc9e5bb..6d538ec24b3f2 100644
  #include "base/memory/ptr_util.h"
  #include "base/metrics/field_trial.h"
 @@ -34,6 +35,7 @@
- #include "base/trace_event/trace_event.h"
+ #include "base/types/optional_util.h"
  #include "base/values.h"
  #include "build/build_config.h"
-+#include "net/base/escape.h"
++#include "base/strings/escape.h"
  #include "net/base/features.h"
  #include "net/base/host_port_pair.h"
  #include "net/base/http_user_agent_settings.h"
@@ -796,7 +738,7 @@ index 2db8e1bc9e5bb..6d538ec24b3f2 100644
 +              if (key.compare("url") == 0) {
 +                // see GetUnescapedValue, TODO check is_valid() before set
 +                request_info_.url =
-+                    GURL(net::UnescapeURLComponent(value, UnescapeRule::NORMAL));
++                    GURL(base::UnescapeURLComponent(value, base::UnescapeRule::NORMAL));
 +             } else if (key.compare("salt") == 0) {
 +                     salt = value;
 +              } else if (key.rfind(headerPrefix, 0) == 0 &&

--- a/native/0002-geneva-dns-and-api-txt.patch
+++ b/native/0002-geneva-dns-and-api-txt.patch
@@ -1,4 +1,4 @@
- components/cronet/android/api.txt                  |   5 +-
+ components/cronet/android/api.txt                  |   7 +-
  .../api/src/org/chromium/net/CronetEngine.java     |  11 +
  .../org/chromium/net/ExperimentalCronetEngine.java |   1 +
  .../src/org/chromium/net/ICronetEngineBuilder.java |   6 +
@@ -7,31 +7,39 @@
  .../cronet/android/implementation_api_version.txt  |   2 +-
  .../cronet/android/interface_api_version.txt       |   2 +-
  .../org/chromium/net/impl/CronetUrlRequest.java    |  17 +-
- .../chromium/net/impl/CronetUrlRequestContext.java |  24 +-
+ .../chromium/net/impl/CronetUrlRequestContext.java |  13 +-
  .../net/impl/NativeCronetEngineBuilderImpl.java    |  17 +-
- components/cronet/cronet_url_request.cc            |  17 +
- components/cronet/cronet_url_request.h             |  10 +
+ components/cronet/cronet_url_request.cc            |  16 +
+ components/cronet/cronet_url_request.h             |   9 +
  net/dns/context_host_resolver.cc                   |   9 +
  net/dns/context_host_resolver.h                    |   2 +
- net/dns/dns_query.cc                               | 501 ++++++++++++++++++++-
+ net/dns/dns_query.cc                               | 380 ++++++++++++++++++---
  net/dns/dns_query.h                                |  37 +-
- net/dns/dns_response.cc                            |  59 ++-
+ net/dns/dns_response.cc                            |  59 +++-
  net/dns/dns_test_util.cc                           |   2 +
- net/dns/dns_transaction.cc                         |  35 +-
+ net/dns/dns_transaction.cc                         |  32 +-
  net/dns/dns_transaction.h                          |   3 +
  net/dns/host_resolver.cc                           |   8 +
  net/dns/host_resolver.h                            |   7 +-
- net/dns/host_resolver_manager.cc                   |  69 ++-
+ net/dns/host_resolver_manager.cc                   |  68 +++-
  net/dns/host_resolver_manager.h                    |   7 +
  net/url_request/url_request_context.cc             |  10 +
  net/url_request/url_request_context.h              |   6 +
- 27 files changed, 834 insertions(+), 41 deletions(-)
+ 27 files changed, 664 insertions(+), 75 deletions(-)
 
 diff --git a/components/cronet/android/api.txt b/components/cronet/android/api.txt
-index cc19e7d3317fc..d16cbcd19b341 100644
+index f6bef3d5fccc4..5a85d6a81bbc5 100644
 --- a/components/cronet/android/api.txt
 +++ b/components/cronet/android/api.txt
-@@ -68,6 +68,7 @@ public class org.chromium.net.CronetEngine$Builder {
+@@ -57,6 +57,7 @@ public class org.chromium.net.CronetEngine$Builder {
+   public org.chromium.net.CronetEngine$Builder(org.chromium.net.ICronetEngineBuilder);
+   public java.lang.String getDefaultUserAgent();
+   public org.chromium.net.CronetEngine$Builder setUserAgent(java.lang.String);
++  public org.chromium.net.CronetEngine$Builder setEnvoyUrl(java.lang.String);
+   public org.chromium.net.CronetEngine$Builder setStoragePath(java.lang.String);
+   public org.chromium.net.CronetEngine$Builder setLibraryLoader(org.chromium.net.CronetEngine$Builder$LibraryLoader);
+   public org.chromium.net.CronetEngine$Builder enableQuic(boolean);
+@@ -67,6 +68,7 @@ public class org.chromium.net.CronetEngine$Builder {
    public org.chromium.net.CronetEngine$Builder addQuicHint(java.lang.String, int, int);
    public org.chromium.net.CronetEngine$Builder addPublicKeyPins(java.lang.String, java.util.Set<byte[]>, boolean, java.util.Date);
    public org.chromium.net.CronetEngine$Builder enablePublicKeyPinningBypassForLocalTrustAnchors(boolean);
@@ -39,7 +47,7 @@ index cc19e7d3317fc..d16cbcd19b341 100644
    public org.chromium.net.CronetEngine build();
  }
  public abstract class org.chromium.net.CronetEngine {
-@@ -79,6 +80,7 @@ public abstract class org.chromium.net.CronetEngine {
+@@ -78,6 +80,7 @@ public abstract class org.chromium.net.CronetEngine {
    public abstract byte[] getGlobalMetricsDeltas();
    public abstract java.net.URLConnection openConnection(java.net.URL) throws java.io.IOException;
    public abstract java.net.URLStreamHandlerFactory createURLStreamHandlerFactory();
@@ -47,7 +55,11 @@ index cc19e7d3317fc..d16cbcd19b341 100644
    public abstract org.chromium.net.UrlRequest$Builder newUrlRequestBuilder(java.lang.String, org.chromium.net.UrlRequest$Callback, java.util.concurrent.Executor);
  }
  public abstract class org.chromium.net.CronetException extends java.io.IOException {
-@@ -222,6 +224,7 @@ public abstract class org.chromium.net.ICronetEngineBuilder {
+@@ -218,9 +221,11 @@ public abstract class org.chromium.net.ICronetEngineBuilder {
+   public abstract org.chromium.net.ICronetEngineBuilder setStoragePath(java.lang.String);
+   public abstract org.chromium.net.ICronetEngineBuilder setUserAgent(java.lang.String);
+   public abstract java.lang.String getDefaultUserAgent();
++  public abstract org.chromium.net.ICronetEngineBuilder setEnvoyUrl(java.lang.String);
    public abstract org.chromium.net.ExperimentalCronetEngine build();
    public org.chromium.net.ICronetEngineBuilder enableNetworkQualityEstimator(boolean);
    public org.chromium.net.ICronetEngineBuilder setThreadPriority(int);
@@ -55,14 +67,14 @@ index cc19e7d3317fc..d16cbcd19b341 100644
  }
  public final class org.chromium.net.InlineExecutionProhibitedException extends java.util.concurrent.RejectedExecutionException {
    public org.chromium.net.InlineExecutionProhibitedException();
-@@ -403,4 +406,4 @@ public abstract class org.chromium.net.UrlResponseInfo {
-   public abstract java.lang.String getProxyServer();
-   public abstract long getReceivedByteCount();
+@@ -395,4 +400,4 @@ public final class org.chromium.net.apihelpers.UploadDataProviders {
+   public static org.chromium.net.UploadDataProvider create(byte[], int, int);
+   public static org.chromium.net.UploadDataProvider create(byte[]);
  }
--Stamp: bffce221f97cb5b4511b1058a20d82e2
-+Stamp: d06e46b217f98eba5bccf2a2e26495c8
+-Stamp: 9ca96d8e2cee4df3a62cefff1a431d5a
++Stamp: a480ae599bf93318cd9905fa85ef4a0d
 diff --git a/components/cronet/android/api/src/org/chromium/net/CronetEngine.java b/components/cronet/android/api/src/org/chromium/net/CronetEngine.java
-index cf7a6c385349f..f2159c8575804 100644
+index af658b248e122..8bad676d2906e 100644
 --- a/components/cronet/android/api/src/org/chromium/net/CronetEngine.java
 +++ b/components/cronet/android/api/src/org/chromium/net/CronetEngine.java
 @@ -311,6 +311,15 @@ public abstract class CronetEngine {
@@ -91,19 +103,19 @@ index cf7a6c385349f..f2159c8575804 100644
       * Creates a builder for {@link UrlRequest}. All callbacks for
       * generated {@link UrlRequest} objects will be invoked on
 diff --git a/components/cronet/android/api/src/org/chromium/net/ExperimentalCronetEngine.java b/components/cronet/android/api/src/org/chromium/net/ExperimentalCronetEngine.java
-index 4e98c3a642bae..dadb00ed33af4 100644
+index defa971c49297..87a507fea8a25 100644
 --- a/components/cronet/android/api/src/org/chromium/net/ExperimentalCronetEngine.java
 +++ b/components/cronet/android/api/src/org/chromium/net/ExperimentalCronetEngine.java
-@@ -413,6 +413,7 @@ public abstract class ExperimentalCronetEngine extends CronetEngine {
+@@ -416,6 +416,7 @@ public abstract class ExperimentalCronetEngine extends CronetEngine {
          return CONNECTION_METRIC_UNKNOWN;
      }
  
 +
      /**
-      * Binds the engine to the specified network. All requests created through this engine will use
-      * this network. If this network disconnects all requests will fail, the exact error will
+      * Binds the engine to the specified network handle. All requests created through this engine
+      * will use the network associated to this handle. If this network disconnects all requests will
 diff --git a/components/cronet/android/api/src/org/chromium/net/ICronetEngineBuilder.java b/components/cronet/android/api/src/org/chromium/net/ICronetEngineBuilder.java
-index 9a9bcb4940e05..9222b0c744bb9 100644
+index e645c8218dfc8..f40ef690f04ac 100644
 --- a/components/cronet/android/api/src/org/chromium/net/ICronetEngineBuilder.java
 +++ b/components/cronet/android/api/src/org/chromium/net/ICronetEngineBuilder.java
 @@ -52,4 +52,10 @@ public abstract class ICronetEngineBuilder {
@@ -113,15 +125,15 @@ index 9a9bcb4940e05..9222b0c744bb9 100644
 +
 +    // [breakerspace]
 +    public void SetStrategy(int packet_strategy) {
-+    	// default implementation does nothing
-+	assert true;
++        // default implementation does nothing
++        assert true;
 +    }
  }
 diff --git a/components/cronet/android/cronet_url_request_adapter.cc b/components/cronet/android/cronet_url_request_adapter.cc
-index 03462e583f538..df42b005d228c 100644
+index eb87408ba7aa8..9453a6dcb754d 100644
 --- a/components/cronet/android/cronet_url_request_adapter.cc
 +++ b/components/cronet/android/cronet_url_request_adapter.cc
-@@ -150,6 +150,11 @@ void CronetURLRequestAdapter::SetUpload(
+@@ -147,6 +147,11 @@ void CronetURLRequestAdapter::SetUpload(
    request_->SetUpload(std::move(upload));
  }
  
@@ -134,97 +146,97 @@ index 03462e583f538..df42b005d228c 100644
                                      const JavaParamRef<jobject>& jcaller) {
    request_->Start();
 diff --git a/components/cronet/android/cronet_url_request_adapter.h b/components/cronet/android/cronet_url_request_adapter.h
-index 0c9a13df6b3e2..e97e75a2d8937 100644
+index c299277e95b86..7f1bdd9f1e475 100644
 --- a/components/cronet/android/cronet_url_request_adapter.h
 +++ b/components/cronet/android/cronet_url_request_adapter.h
-@@ -79,6 +79,9 @@ class CronetURLRequestAdapter : public CronetURLRequest::Callback {
+@@ -78,6 +78,9 @@ class CronetURLRequestAdapter : public CronetURLRequest::Callback {
    // Adds a request body to the request before it starts.
    void SetUpload(std::unique_ptr<net::UploadDataStream> upload);
  
 +  //[breakerspace]
 +  void SetStrategy(JNIEnv* env, const base::android::JavaParamRef<jobject>& jcaller, jint packet_strategy);
-+  
++
    // Starts the request.
    void Start(JNIEnv* env, const base::android::JavaParamRef<jobject>& jcaller);
  
 diff --git a/components/cronet/android/implementation_api_version.txt b/components/cronet/android/implementation_api_version.txt
-index b6a7d89c68e0c..98d9bcb75a685 100644
+index 98d9bcb75a685..3c032078a4a21 100644
 --- a/components/cronet/android/implementation_api_version.txt
 +++ b/components/cronet/android/implementation_api_version.txt
 @@ -1 +1 @@
--16
-+17
+-17
++18
 diff --git a/components/cronet/android/interface_api_version.txt b/components/cronet/android/interface_api_version.txt
-index b6a7d89c68e0c..98d9bcb75a685 100644
+index 98d9bcb75a685..3c032078a4a21 100644
 --- a/components/cronet/android/interface_api_version.txt
 +++ b/components/cronet/android/interface_api_version.txt
 @@ -1 +1 @@
--16
-+17
+-17
++18
 diff --git a/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequest.java b/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequest.java
-index 20473d157e0f2..0a77eb35252cf 100644
+index 590d29c1b09ae..e34692a7f2268 100644
 --- a/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequest.java
 +++ b/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequest.java
-@@ -117,6 +117,9 @@ public final class CronetUrlRequest extends UrlRequestBase {
+@@ -120,6 +120,9 @@ public final class CronetUrlRequest extends UrlRequestBase {
       */
      private OnReadCompletedRunnable mOnReadCompletedTask;
  
 +    // [breakerspace]
 +    int strategy;
-+    
++
      @GuardedBy("mUrlRequestAdapterLock")
      private Runnable mOnDestroyedCallbackForTesting;
  
-@@ -216,6 +219,10 @@ public final class CronetUrlRequest extends UrlRequestBase {
+@@ -222,6 +225,10 @@ public final class CronetUrlRequest extends UrlRequestBase {
          mUploadDataStream = new CronetUploadDataStream(uploadDataProvider, executor, this);
      }
  
 +    public void SetStrategy(int packet_strategy) {
-+    	strategy = packet_strategy;
++        strategy = packet_strategy;
 +    }
 +
      @Override
      public void start() {
          synchronized (mUrlRequestAdapterLock) {
-@@ -230,7 +237,11 @@ public final class CronetUrlRequest extends UrlRequestBase {
+@@ -234,7 +241,11 @@ public final class CronetUrlRequest extends UrlRequestBase {
                          mTrafficStatsTagSet, mTrafficStatsTag, mTrafficStatsUidSet,
                          mTrafficStatsUid, mIdempotency, mNetworkHandle);
                  mRequestContext.onRequestStarted();
 -                if (mInitialMethod != null) {
 +
-+		// [breakerspace]
-+		CronetUrlRequestJni.get().SetStrategy(mUrlRequestAdapter, CronetUrlRequest.this, strategy);
++        // [breakerspace]
++        CronetUrlRequestJni.get().SetStrategy(mUrlRequestAdapter, CronetUrlRequest.this, strategy);
 +
-+		if (mInitialMethod != null) {
++        if (mInitialMethod != null) {
                      if (!CronetUrlRequestJni.get().setHttpMethod(
                                  mUrlRequestAdapter, CronetUrlRequest.this, mInitialMethod)) {
                          throw new IllegalArgumentException("Invalid http method " + mInitialMethod);
-@@ -866,6 +877,10 @@ public final class CronetUrlRequest extends UrlRequestBase {
+@@ -1005,6 +1016,10 @@ public final class CronetUrlRequest extends UrlRequestBase {
          @NativeClassQualifiedName("CronetURLRequestAdapter")
          boolean setHttpMethod(long nativePtr, CronetUrlRequest caller, String method);
  
-+	// [breakerspace]
-+	@NativeClassQualifiedName("CronetURLRequestAdapter")
-+	void SetStrategy(long nativePtr, CronetUrlRequest caller, int packet_strategy);
++    // [breakerspace]
++    @NativeClassQualifiedName("CronetURLRequestAdapter")
++    void SetStrategy(long nativePtr, CronetUrlRequest caller, int packet_strategy);
 +
          @NativeClassQualifiedName("CronetURLRequestAdapter")
          boolean addRequestHeader(
                  long nativePtr, CronetUrlRequest caller, String name, String value);
 diff --git a/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java b/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java
-index 8e2f755183fe8..045a0183f3d60 100644
+index 0ac80eb23964c..2ff07ccada289 100644
 --- a/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java
 +++ b/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java
-@@ -160,6 +160,9 @@ public class CronetUrlRequestContext extends CronetEngineBase {
-     /** If not null, the network to be used for requests that do not explicitly specify one. **/
-     private @Nullable Network mNetwork;
+@@ -178,6 +178,9 @@ public class CronetUrlRequestContext extends CronetEngineBase {
+         return mLogger;
+     }
  
 +    // [breakerspace]
 +    private int strategy;
-+    
++
      @UsedByReflection("CronetEngine.java")
      public CronetUrlRequestContext(final CronetEngineBuilderImpl builder) {
-         mRttListenerList.disableThreadAsserts();
-@@ -235,6 +238,11 @@ public class CronetUrlRequestContext extends CronetEngineBase {
+         mCronetEngineId = hashCode();
+@@ -276,6 +279,11 @@ public class CronetUrlRequestContext extends CronetEngineBase {
          return new BidirectionalStreamBuilderImpl(url, callback, executor, this);
      }
  
@@ -236,34 +248,23 @@ index 8e2f755183fe8..045a0183f3d60 100644
      @Override
      public UrlRequestBase createRequest(String url, UrlRequest.Callback callback, Executor executor,
              int priority, Collection<Object> requestAnnotations, boolean disableCache,
-@@ -247,11 +255,23 @@ public class CronetUrlRequestContext extends CronetEngineBase {
+@@ -288,10 +296,13 @@ public class CronetUrlRequestContext extends CronetEngineBase {
          }
          synchronized (mLock) {
              checkHaveAdapter();
 -            return new CronetUrlRequest(this, url, priority, callback, executor, requestAnnotations,
-+
-+	    CronetUrlRequest temp = new CronetUrlRequest(this, url, priority, callback, executor, requestAnnotations,
++            CronetUrlRequest temp = new CronetUrlRequest(this, url, priority, callback, executor, requestAnnotations,
                      disableCache, disableConnectionMigration, allowDirectExecutor,
                      trafficStatsTagSet, trafficStatsTag, trafficStatsUidSet, trafficStatsUid,
-                     requestFinishedListener, idempotency, network);
--        }
+                     requestFinishedListener, idempotency, networkHandle);
++            temp.SetStrategy(strategy);
 +
-+	    temp.SetStrategy(strategy);
-+
-+	    return temp;
-+
-+            /* [breakerspace]
-+	    return new CronetUrlRequest(this, url, priority, callback, executor, requestAnnotations,
-+                    disableCache, disableConnectionMigration, allowDirectExecutor,
-+                    trafficStatsTagSet, trafficStatsTag, trafficStatsUidSet, trafficStatsUid,
-+                    requestFinishedListener, idempotency, network);
-+            */
-+	}
++            return temp;
+         }
      }
  
-     @Override
 diff --git a/components/cronet/android/java/src/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java b/components/cronet/android/java/src/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
-index 696d7c8455b3d..3c84f1d852c3c 100644
+index faa87a91fb25d..cca200f45153e 100644
 --- a/components/cronet/android/java/src/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
 +++ b/components/cronet/android/java/src/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
 @@ -13,7 +13,9 @@ import org.chromium.net.ICronetEngineBuilder;
@@ -271,8 +272,8 @@ index 696d7c8455b3d..3c84f1d852c3c 100644
   */
  public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
 -    /**
-+     private int strategy; 
-+       
++     private int strategy;
++
 +     /**
       * Builder for Native Cronet Engine.
       * Default config enables SPDY, disables QUIC and HTTP cache.
@@ -294,7 +295,7 @@ index 696d7c8455b3d..3c84f1d852c3c 100644
  
 -        ExperimentalCronetEngine builder = new CronetUrlRequestContext(this);
 +        /* [breakerspace] */ //ExperimentalCronetEngine builder = new CronetUrlRequestContext(this);
-+	
++
 +	CronetUrlRequestContext builder = new CronetUrlRequestContext(this);
 +
 +        // [breakerspace]
@@ -309,10 +310,10 @@ index 696d7c8455b3d..3c84f1d852c3c 100644
 +
  }
 diff --git a/components/cronet/cronet_url_request.cc b/components/cronet/cronet_url_request.cc
-index 3a8c621149318..7a638a2fdab64 100644
+index 591a848f14d74..a629827eab815 100644
 --- a/components/cronet/cronet_url_request.cc
 +++ b/components/cronet/cronet_url_request.cc
-@@ -281,6 +281,19 @@ void CronetURLRequest::NetworkTasks::OnReadCompleted(net::URLRequest* request,
+@@ -276,6 +276,18 @@ void CronetURLRequest::NetworkTasks::OnReadCompleted(net::URLRequest* request,
    read_buffer_ = nullptr;
  }
  
@@ -323,7 +324,6 @@ index 3a8c621149318..7a638a2fdab64 100644
 +	//}
 +}
 +
-+
 +// [breakerspace]
 +void CronetURLRequest::NetworkTasks::SetStrategy(unsigned int packet_strategy) {
 +	strategy = packet_strategy;
@@ -332,11 +332,11 @@ index 3a8c621149318..7a638a2fdab64 100644
  void CronetURLRequest::NetworkTasks::Start(
      CronetContext* context,
      const std::string& method,
-@@ -291,6 +304,10 @@ void CronetURLRequest::NetworkTasks::Start(
+@@ -286,6 +298,10 @@ void CronetURLRequest::NetworkTasks::Start(
    VLOG(1) << "Starting chromium request: "
            << initial_url_.possibly_invalid_spec().c_str()
            << " priority: " << RequestPriorityToString(initial_priority_);
-+  
++
 +  // [breakerspace]
 +  context->GetURLRequestContext(network_)->SetStrategy(strategy);
 +
@@ -344,31 +344,30 @@ index 3a8c621149318..7a638a2fdab64 100644
        initial_url_, net::DEFAULT_PRIORITY, this, MISSING_TRAFFIC_ANNOTATION);
    url_request_->SetLoadFlags(initial_load_flags_);
 diff --git a/components/cronet/cronet_url_request.h b/components/cronet/cronet_url_request.h
-index fad98e70b40ad..12da447c6c29b 100644
+index ab27797989898..a6fd1015e2ca9 100644
 --- a/components/cronet/cronet_url_request.h
 +++ b/components/cronet/cronet_url_request.h
-@@ -195,6 +195,9 @@ class CronetURLRequest {
+@@ -196,6 +196,9 @@ class CronetURLRequest {
    // used by the callback are deleted.
    void MaybeReportMetricsAndRunCallback(base::OnceClosure callback);
  
 +  // [breakerspace]
 +  void SetStrategy(unsigned int packet_strategy);
-+ 
++
   private:
    friend class TestUtil;
  
-@@ -224,6 +227,10 @@ class CronetURLRequest {
+@@ -224,6 +227,9 @@ class CronetURLRequest {
      // Invoked on the network thread.
      ~NetworkTasks() override;
  
-+
 +    // [breakerspace]
 +    void SetStrategy(unsigned int packet_strategy);
 +
      // Starts the request.
      void Start(CronetContext* context,
                 const std::string& method,
-@@ -305,6 +312,9 @@ class CronetURLRequest {
+@@ -303,6 +309,9 @@ class CronetURLRequest {
      scoped_refptr<net::IOBuffer> read_buffer_;
      std::unique_ptr<net::URLRequest> url_request_;
  
@@ -379,7 +378,7 @@ index fad98e70b40ad..12da447c6c29b 100644
    };
  
 diff --git a/net/dns/context_host_resolver.cc b/net/dns/context_host_resolver.cc
-index c29c19e8314e9..6a21601280056 100644
+index 9773076f60c59..e5170afb20792 100644
 --- a/net/dns/context_host_resolver.cc
 +++ b/net/dns/context_host_resolver.cc
 @@ -74,6 +74,7 @@ ContextHostResolver::CreateRequest(
@@ -406,23 +405,23 @@ index c29c19e8314e9..6a21601280056 100644
  std::unique_ptr<HostResolver::ResolveHostRequest>
  ContextHostResolver::CreateRequest(
 diff --git a/net/dns/context_host_resolver.h b/net/dns/context_host_resolver.h
-index db881697e2241..0e56065ba29ce 100644
+index fb537024f8dc5..bb79ea9617d40 100644
 --- a/net/dns/context_host_resolver.h
 +++ b/net/dns/context_host_resolver.h
-@@ -82,6 +82,8 @@ class NET_EXPORT ContextHostResolver : public HostResolver {
-   void SetProcParamsForTesting(const ProcTaskParams& proc_params);
-   void SetTickClockForTesting(const base::TickClock* tick_clock);
+@@ -87,6 +87,8 @@ class NET_EXPORT ContextHostResolver : public HostResolver {
+     return resolve_context_.get();
+   }
  
 +  //[breakerspace]
 +  void SetStrategyInManager(unsigned int packet_strategy) override;
   private:
-   const raw_ptr<HostResolverManager> manager_;
    std::unique_ptr<HostResolverManager> owned_manager_;
+   // `manager_` might point to `owned_manager_`. It must be declared last and
 diff --git a/net/dns/dns_query.cc b/net/dns/dns_query.cc
-index 75faae360b472..ae9a86f18ffab 100644
+index 6f93a819d4d6a..42d05f066bd08 100644
 --- a/net/dns/dns_query.cc
 +++ b/net/dns/dns_query.cc
-@@ -62,6 +62,8 @@ absl::optional<OptRecordRdata> AddPaddingIfNecessary(
+@@ -63,6 +63,8 @@ std::unique_ptr<OptRecordRdata> AddPaddingIfNecessary(
      const OptRecordRdata* opt_rdata,
      DnsQuery::PaddingStrategy padding_strategy,
      size_t no_opt_buffer_size) {
@@ -430,17 +429,16 @@ index 75faae360b472..ae9a86f18ffab 100644
 +  VLOG(1) << "[breakerspace] AddPaddingIfNecessary()";
    // If no input OPT record rdata and no padding, no OPT record rdata needed.
    if (!opt_rdata && padding_strategy == DnsQuery::PaddingStrategy::NONE)
-     return absl::nullopt;
-@@ -90,22 +92,353 @@ absl::optional<OptRecordRdata> AddPaddingIfNecessary(
+     return nullptr;
+@@ -96,6 +98,265 @@ std::unique_ptr<OptRecordRdata> AddPaddingIfNecessary(
  
  }  // namespace
  
-+
-+void DnsQuery::AddPadding(absl::optional<OptRecordRdata>* merged_opt_rdata, base::BigEndianWriter* writer) {
-+  if (*merged_opt_rdata) {
++void DnsQuery::AddPadding(std::unique_ptr<OptRecordRdata>* merged_opt_rdata, base::BigEndianWriter* writer) {
++  if (merged_opt_rdata != nullptr) {
 +
 +    VLOG(1) << "[breakerspace] merged_opt_rdata";
-+    DCHECK(!merged_opt_rdata->value().opts().empty());
++    DCHECK(!(*merged_opt_rdata)->opts().empty());
 +
 +    header_->arcount = base::HostToNet16(1);
 +    // Write OPT pseudo-resource record.
@@ -455,270 +453,257 @@ index 75faae360b472..ae9a86f18ffab 100644
 +    writer->WriteU16(0);  // flags
 +
 +    // rdata
-+    writer->WriteU16(merged_opt_rdata->value().buf().size());  // rdata length
-+    writer->WriteBytes(merged_opt_rdata->value().buf().data(),
-+                      merged_opt_rdata->value().buf().size());
++    writer->WriteU16((*merged_opt_rdata)->buf().size());  // rdata length
++    writer->WriteBytes((*merged_opt_rdata)->buf().data(),
++                       (*merged_opt_rdata)->buf().size());
 +  }
 +
 +}
 +
 +//Creates an IOBuffer with the appropriate size and gives its header the default settings (RD flag set and qdcount 1)
 +void DnsQuery::CreateIOBufferAndHeader(uint16_t id, const base::StringPiece& qname, uint16_t qtype, size_t size) {
-+	size_t buffer_size = size;
++   size_t buffer_size = size;
 +
-+	io_buffer_ = base::MakeRefCounted<IOBufferWithSize>(buffer_size);
++   io_buffer_ = base::MakeRefCounted<IOBufferWithSize>(buffer_size);
 +
-+	header_ = reinterpret_cast<dns_protocol::Header*>(io_buffer_->data());
-+  	*header_ = {};
-+  	header_->id = base::HostToNet16(id);
++   header_ = reinterpret_cast<dns_protocol::Header*>(io_buffer_->data());
++   *header_ = {};
++   header_->id = base::HostToNet16(id);
 +
-+	header_->flags = base::HostToNet16(dns_protocol::kFlagRD);
++   header_->flags = base::HostToNet16(dns_protocol::kFlagRD);
 +
-+	header_->qdcount = base::HostToNet16(1);
++   header_->qdcount = base::HostToNet16(1);
 +}
 +
 +void DnsQuery::UnmodifiedStrategy(uint16_t id, const base::StringPiece& qname, uint16_t qtype,
 +                const OptRecordRdata* opt_rdata, PaddingStrategy padding_strategy) {
 +
-+	size_t buffer_size = kHeaderSize + QuestionSize(qname.size());
++   size_t buffer_size = kHeaderSize + QuestionSize(qname.size());
 +
-+        qname_size_ = qname.size();
++   qname_size_ = qname.size();
 +
-+        absl::optional<OptRecordRdata> merged_opt_rdata = AddPaddingIfNecessary(opt_rdata, padding_strategy, buffer_size);
++   std::unique_ptr<OptRecordRdata> merged_opt_rdata = AddPaddingIfNecessary(opt_rdata, padding_strategy, buffer_size);
 +
-+        if (merged_opt_rdata)
-+                buffer_size += OptRecordSize(&merged_opt_rdata.value());
++   buffer_size += OptRecordSize(merged_opt_rdata.get());
 +
-+        CreateIOBufferAndHeader(id, qname, qtype, buffer_size);
++   CreateIOBufferAndHeader(id, qname, qtype, buffer_size);
 +
-+        //Write a question record
-+        base::BigEndianWriter writer(io_buffer_->data() + kHeaderSize,
-+                               io_buffer_->size() - kHeaderSize);
-+        writer.WriteBytes(qname.data(), qname.size());
-+        writer.WriteU16(qtype);
-+        writer.WriteU16(dns_protocol::kClassIN);
++   //Write a question record
++   base::BigEndianWriter writer(io_buffer_->data() + kHeaderSize,
++                                io_buffer_->size() - kHeaderSize);
++   writer.WriteBytes(qname.data(), qname.size());
++   writer.WriteU16(qtype);
++   writer.WriteU16(dns_protocol::kClassIN);
 +
-+        if (merged_opt_rdata) {
-+           AddPadding(&merged_opt_rdata, &writer);
-+        }
++   if (merged_opt_rdata) {
++      AddPadding(&merged_opt_rdata, &writer);
++   }
 +}
++
 +void DnsQuery::ElevatedCountStrategy(uint16_t id, const base::StringPiece& qname, uint16_t qtype,
-+		const OptRecordRdata* opt_rdata, PaddingStrategy padding_strategy) {
-+	
++       const OptRecordRdata* opt_rdata, PaddingStrategy padding_strategy) {
 +
-+	size_t buffer_size = kHeaderSize + QuestionSize(qname.size());
-+	
-+	qname_size_ = qname.size();
-+	
-+	absl::optional<OptRecordRdata> merged_opt_rdata = AddPaddingIfNecessary(opt_rdata, padding_strategy, buffer_size);
-+  	
-+	if (merged_opt_rdata)
-+    		buffer_size += OptRecordSize(&merged_opt_rdata.value());
-+	
-+	CreateIOBufferAndHeader(id, qname, qtype, buffer_size);
 +
-+	//Set qdcount to 2	
-+	header_->qdcount = base::HostToNet16(2);
++   size_t buffer_size = kHeaderSize + QuestionSize(qname.size());
 +
-+	//Write a question record
-+	base::BigEndianWriter writer(io_buffer_->data() + kHeaderSize,
++   qname_size_ = qname.size();
++
++   std::unique_ptr<OptRecordRdata> merged_opt_rdata = AddPaddingIfNecessary(opt_rdata, padding_strategy, buffer_size);
++
++   if (merged_opt_rdata)
++           buffer_size += OptRecordSize(merged_opt_rdata.get());
++
++   CreateIOBufferAndHeader(id, qname, qtype, buffer_size);
++
++   //Set qdcount to 2
++   header_->qdcount = base::HostToNet16(2);
++
++   //Write a question record
++   base::BigEndianWriter writer(io_buffer_->data() + kHeaderSize,
 +                               io_buffer_->size() - kHeaderSize);
-+	writer.WriteBytes(qname.data(), qname.size());
-+	writer.WriteU16(qtype);
-+	writer.WriteU16(dns_protocol::kClassIN);
++   writer.WriteBytes(qname.data(), qname.size());
++   writer.WriteU16(qtype);
++   writer.WriteU16(dns_protocol::kClassIN);
 +
-+	if (merged_opt_rdata) {
-+	   AddPadding(&merged_opt_rdata, &writer);
-+	}
++   if (merged_opt_rdata) {
++      AddPadding(&merged_opt_rdata, &writer);
++   }
 +}
 +
 +void DnsQuery::TruncatedReservedStrategy(uint16_t id, const base::StringPiece& qname, uint16_t qtype,
 +                const OptRecordRdata* opt_rdata, PaddingStrategy padding_strategy) {
 +
 +
-+        size_t buffer_size = kHeaderSize + QuestionSize(qname.size());
++   size_t buffer_size = kHeaderSize + QuestionSize(qname.size());
 +
-+        qname_size_ = qname.size();
++   qname_size_ = qname.size();
 +
-+        absl::optional<OptRecordRdata> merged_opt_rdata = AddPaddingIfNecessary(opt_rdata, padding_strategy, buffer_size);
++   std::unique_ptr<OptRecordRdata> merged_opt_rdata = AddPaddingIfNecessary(opt_rdata, padding_strategy, buffer_size);
 +
-+        if (merged_opt_rdata)
-+                buffer_size += OptRecordSize(&merged_opt_rdata.value());
++   if (merged_opt_rdata)
++       buffer_size += OptRecordSize(merged_opt_rdata.get());
 +
-+        CreateIOBufferAndHeader(id, qname, qtype, buffer_size);
++   CreateIOBufferAndHeader(id, qname, qtype, buffer_size);
 +
-+	//Setting tc and z flags
-+        uint16_t new_flags = dns_protocol::kFlagRD;
-+  	//0x40 = 0b1000000, setting z to 1.
-+  	new_flags |= 0x40;
-+  	//setting tc to 1
-+  	new_flags |= dns_protocol::kFlagTC;
-+  	//changing header_ flag field
-+  	header_->flags = base::HostToNet16(new_flags);
++   //Setting tc and z flags
++   uint16_t new_flags = dns_protocol::kFlagRD;
++   //0x40 = 0b1000000, setting z to 1.
++   new_flags |= 0x40;
++   //setting tc to 1
++   new_flags |= dns_protocol::kFlagTC;
++   //changing header_ flag field
++   header_->flags = base::HostToNet16(new_flags);
 +
-+	//changing nscount
-+	header_->nscount = base::HostToNet16(1);
++   //changing nscount
++   header_->nscount = base::HostToNet16(1);
 +
-+	//writing a question record
-+        base::BigEndianWriter writer(io_buffer_->data() + kHeaderSize,
-+                               io_buffer_->size() - kHeaderSize);
-+        writer.WriteBytes(qname.data(), qname.size());
-+        writer.WriteU16(qtype);
-+        writer.WriteU16(dns_protocol::kClassIN);
++   //writing a question record
++   base::BigEndianWriter writer(io_buffer_->data() + kHeaderSize,
++                                io_buffer_->size() - kHeaderSize);
++   writer.WriteBytes(qname.data(), qname.size());
++   writer.WriteU16(qtype);
++   writer.WriteU16(dns_protocol::kClassIN);
 +
-+        if (merged_opt_rdata) {
-+           AddPadding(&merged_opt_rdata, &writer);
-+        }
++   if (merged_opt_rdata) {
++       AddPadding(&merged_opt_rdata, &writer);
++   }
 +}
 +
 +void DnsQuery::MultiByteStrategy(uint16_t id, const base::StringPiece& qname, uint16_t qtype,
-+                const OptRecordRdata* opt_rdata, PaddingStrategy padding_strategy) {
++                                 const OptRecordRdata* opt_rdata, PaddingStrategy padding_strategy) {
 +
-+	size_t buffer_size = kHeaderSize + QuestionSize(qname.size());
++   size_t buffer_size = kHeaderSize + QuestionSize(qname.size());
 +
-+        qname_size_ = qname.size();
++   qname_size_ = qname.size();
 +
-+	//increase buffer size by 721 2-byte characters
-+        buffer_size += QuestionSize(721 * 2 + 1);
-+	
-+	absl::optional<OptRecordRdata> merged_opt_rdata = AddPaddingIfNecessary(opt_rdata, padding_strategy, buffer_size);
++   //increase buffer size by 721 2-byte characters
++   buffer_size += QuestionSize(721 * 2 + 1);
 +
-+        if (merged_opt_rdata)
-+                buffer_size += OptRecordSize(&merged_opt_rdata.value());
++   std::unique_ptr<OptRecordRdata> merged_opt_rdata = AddPaddingIfNecessary(opt_rdata, padding_strategy, buffer_size);
 +
-+        CreateIOBufferAndHeader(id, qname, qtype, buffer_size);
++   if (merged_opt_rdata)
++       buffer_size += OptRecordSize(merged_opt_rdata.get());
 +
-+        //write first question record
-+        base::BigEndianWriter writer(io_buffer_->data() + kHeaderSize,
-+                               io_buffer_->size() - kHeaderSize);
-+        writer.WriteBytes(qname.data(), qname.size());
-+        writer.WriteU16(qtype);
-+        writer.WriteU16(dns_protocol::kClassIN);
++   CreateIOBufferAndHeader(id, qname, qtype, buffer_size);
 +
-+	unsigned char multibyte_data[721 * 2 + 1];
++   //write first question record
++   base::BigEndianWriter writer(io_buffer_->data() + kHeaderSize,
++                                io_buffer_->size() - kHeaderSize);
++   writer.WriteBytes(qname.data(), qname.size());
++   writer.WriteU16(qtype);
++   writer.WriteU16(dns_protocol::kClassIN);
 +
-+	for(int i = 0; i < 721 * 2; i+=2){
-+      		multibyte_data[i] = 0xc2;
-+      		multibyte_data[i + 1] = 0xa4;
-+  	}
++   unsigned char multibyte_data[721 * 2 + 1];
 +
-+	multibyte_data[721 * 2] = 0;
++   for(int i = 0; i < 721 * 2; i+=2){
++       multibyte_data[i] = 0xc2;
++       multibyte_data[i + 1] = 0xa4;
++   }
 +
-+	//write multibyte characters to a new question record
-+  	writer.WriteBytes(multibyte_data, 721 * 2 + 1);
-+	writer.WriteU16(qtype);
-+  	writer.WriteU16(dns_protocol::kClassIN);
++   multibyte_data[721 * 2] = 0;
 +
-+        if (merged_opt_rdata) {
-+           AddPadding(&merged_opt_rdata, &writer);
-+        }
++   //write multibyte characters to a new question record
++   writer.WriteBytes(multibyte_data, 721 * 2 + 1);
++   writer.WriteU16(qtype);
++   writer.WriteU16(dns_protocol::kClassIN);
++
++   if (merged_opt_rdata) {
++      AddPadding(&merged_opt_rdata, &writer);
++   }
 +
 +}
 +
 +void DnsQuery::MultiByteStrategyElevatedCount(uint16_t id, const base::StringPiece& qname, uint16_t qtype,
 +                const OptRecordRdata* opt_rdata, PaddingStrategy padding_strategy) {
-+	
-+	MultiByteStrategy(id, qname, qtype, opt_rdata, padding_strategy);
 +
-+	header_->arcount = base::HostToNet16(1);
-+
++   MultiByteStrategy(id, qname, qtype, opt_rdata, padding_strategy);
++   header_->arcount = base::HostToNet16(1);
 +}
 +
 +void DnsQuery::CompressedStrategy(uint16_t id, const base::StringPiece& qname, uint16_t qtype,
 +                const OptRecordRdata* opt_rdata, PaddingStrategy padding_strategy) {
 +
-+	size_t buffer_size = kHeaderSize;
++   size_t buffer_size = kHeaderSize;
 +
-+        qname_size_ = qname.size();
++   qname_size_ = qname.size();
 +
++   size_t uncompressed_buffer_size = kHeaderSize + QuestionSize(qname_size_);
++   compressed = true;
++   io_buffer_uncompressed = base::MakeRefCounted<IOBufferWithSize>(uncompressed_buffer_size);
 +
-+	size_t uncompressed_buffer_size = kHeaderSize + QuestionSize(qname_size_);
-+	compressed = true;
-+	io_buffer_uncompressed = base::MakeRefCounted<IOBufferWithSize>(uncompressed_buffer_size);
-+	
-+	//The qname is divided into sections, the first section's length is the 0th element of qname
-+	size_t first_section_length = qname.data()[0];
-+	//The first question record will have first_section_length characters + the length octet +
-+	//the number indicating a pointer + the offset
-+	buffer_size += QuestionSize(first_section_length + 3);
++   //The qname is divided into sections, the first section's length is the 0th element of qname
++   size_t first_section_length = qname.data()[0];
++   //The first question record will have first_section_length characters + the length octet +
++   //the number indicating a pointer + the offset
++   buffer_size += QuestionSize(first_section_length + 3);
 +
-+	VLOG(1) << "[breakerspace] first section length: " << first_section_length;
-+	size_t rest_of_length = qname_size_ - (first_section_length + 1);
-+	buffer_size += QuestionSize(rest_of_length);
++   VLOG(1) << "[breakerspace] first section length: " << first_section_length;
++   size_t rest_of_length = qname_size_ - (first_section_length + 1);
++   buffer_size += QuestionSize(rest_of_length);
 +
++   std::unique_ptr<OptRecordRdata> merged_opt_rdata = AddPaddingIfNecessary(opt_rdata, padding_strategy, buffer_size);
++   if (merged_opt_rdata != nullptr)
++       buffer_size += OptRecordSize(merged_opt_rdata.get());
 +
-+        absl::optional<OptRecordRdata> merged_opt_rdata = AddPaddingIfNecessary(opt_rdata, padding_strategy, buffer_size);
-+        if (merged_opt_rdata)
-+                buffer_size += OptRecordSize(&merged_opt_rdata.value());
++   CreateIOBufferAndHeader(id, qname, qtype, buffer_size);
 +
-+        CreateIOBufferAndHeader(id, qname, qtype, buffer_size);
++   unsigned char* first_section = new unsigned char[first_section_length + 3];
++   first_section[0] = first_section_length;
++   if ((12 + (first_section_length + 3) + 4) > 255) {
++       first_section[first_section_length + 1] = 0xc0 | ((12 + (first_section_length + 3) + 4) >> 8);
++       first_section[first_section_length + 2] = ((12 + (first_section_length + 3) + 4)) & 0xff;
++   } else {
 +
-+        
-+	unsigned char* first_section = new unsigned char[first_section_length + 3];
-+	first_section[0] = first_section_length;
-+	if ((12 + (first_section_length + 3) + 4) > 255) {
-+		first_section[first_section_length + 1] = 0xc0 | ((12 + (first_section_length + 3) + 4) >> 8);
-+		first_section[first_section_length + 2] = ((12 + (first_section_length + 3) + 4)) & 0xff; 
-+	} else {
++       first_section[first_section_length + 1] = 192;
++       first_section[first_section_length + 2] = 12 + (first_section_length + 3) + 4;
++   }
++   for (size_t i = 1; i <= first_section_length; i++) {
++       first_section[i] = qname.data()[i];
++   }
 +
-+		first_section[first_section_length + 1] = 192;
-+		first_section[first_section_length + 2] = 12 + (first_section_length + 3) + 4;
-+	}
-+	for (size_t i = 1; i <= first_section_length; i++) {
-+		first_section[i] = qname.data()[i];
-+	}
++   base::BigEndianWriter writer(io_buffer_->data() + kHeaderSize,
++                                io_buffer_->size() - kHeaderSize);
 +
++   writer.WriteBytes(first_section, first_section_length + 3);
++   writer.WriteU16(qtype);
++   writer.WriteU16(dns_protocol::kClassIN);
 +
++   writer.WriteBytes(&(qname.data()[first_section_length + 1]), rest_of_length);
++   writer.WriteU16(qtype);
++   writer.WriteU16(dns_protocol::kClassIN);
 +
-+	base::BigEndianWriter writer(io_buffer_->data() + kHeaderSize,
-+                               io_buffer_->size() - kHeaderSize);
++   header_->qdcount = base::HostToNet16(2);
 +
-+        writer.WriteBytes(first_section, first_section_length + 3);
-+  	writer.WriteU16(qtype);
-+  	writer.WriteU16(dns_protocol::kClassIN);
++   dns_protocol::Header* header_uncompressed;
++   header_uncompressed = reinterpret_cast<dns_protocol::Header*>(io_buffer_uncompressed->data());
++   *header_uncompressed = {};
++   header_uncompressed->id = base::HostToNet16(id);
++   header_->flags = base::HostToNet16(dns_protocol::kFlagRD);
++   header_uncompressed->qdcount = base::HostToNet16(2);
 +
-+
-+  	writer.WriteBytes(&(qname.data()[first_section_length + 1]), rest_of_length);
-+  	writer.WriteU16(qtype);
-+  	writer.WriteU16(dns_protocol::kClassIN);
-+
-+	header_->qdcount = base::HostToNet16(2);
-+
-+
-+
-+  	dns_protocol::Header* header_uncompressed;
-+     	header_uncompressed = reinterpret_cast<dns_protocol::Header*>(io_buffer_uncompressed->data());
-+     	*header_uncompressed = {};
-+     	header_uncompressed->id = base::HostToNet16(id);
-+     	header_->flags = base::HostToNet16(dns_protocol::kFlagRD);
-+     	header_uncompressed->qdcount = base::HostToNet16(2);
-+
-+     	VLOG(1) << "[breakerspace] qname.data() = " << qname.data();
-+     	base::BigEndianWriter uncompressed_writer(io_buffer_uncompressed->data() + kHeaderSize,
++   VLOG(1) << "[breakerspace] qname.data() = " << qname.data();
++   base::BigEndianWriter uncompressed_writer(io_buffer_uncompressed->data() + kHeaderSize,
 +                                                io_buffer_uncompressed->size() - kHeaderSize);
-+     	uncompressed_writer.WriteBytes(qname.data(), qname.size());
-+     	uncompressed_writer.WriteU16(qtype);
-+     	uncompressed_writer.WriteU16(dns_protocol::kClassIN);
++   uncompressed_writer.WriteBytes(qname.data(), qname.size());
++   uncompressed_writer.WriteU16(qtype);
++   uncompressed_writer.WriteU16(dns_protocol::kClassIN);
 +
-+        if (merged_opt_rdata) {
-+           AddPadding(&merged_opt_rdata, &writer);
-+        }
-+
++   if (merged_opt_rdata) {
++       AddPadding(&merged_opt_rdata, &writer);
++   }
 +}
 +
  // DNS query consists of a 12-byte header followed by a question section.
  // For details, see RFC 1035 section 4.1.1.  This header template sets RD
  // bit, which directs the name server to pursue query recursively, and sets
- // the QDCOUNT to 1, meaning the question section has a single entry.
-+
- DnsQuery::DnsQuery(uint16_t id,
+@@ -104,56 +365,41 @@ DnsQuery::DnsQuery(uint16_t id,
                     const base::StringPiece& qname,
                     uint16_t qtype,
                     const OptRecordRdata* opt_rdata,
 -                   PaddingStrategy padding_strategy)
 -    : qname_size_(qname.size()) {
 +                   PaddingStrategy padding_strategy,
-+		   unsigned int packet_strategy)
++                   unsigned int packet_strategy)
 +    : qname_size_(qname.size()), strategy(packet_strategy) {
  #if DCHECK_IS_ON()
    absl::optional<std::string> dotted_name = DnsDomainToString(qname);
@@ -726,206 +711,76 @@ index 75faae360b472..ae9a86f18ffab 100644
  #endif  // DCHECK_IS_ON()
  
 -  size_t buffer_size = kHeaderSize + QuestionSize(qname_size_);
-+  VLOG(1) << "[breakerspace] DnsQuery::DnsQuery()";
-+  
-+  switch (strategy) {
-+	case 1:
-+		ElevatedCountStrategy(id, qname, qtype, opt_rdata, padding_strategy);
-+		break;
-+	case 2:
-+		TruncatedReservedStrategy(id, qname, qtype, opt_rdata, padding_strategy);
-+		break;
-+	case 3:
-+		MultiByteStrategy(id, qname, qtype, opt_rdata, padding_strategy);
-+		break;
-+	case 4:
-+		MultiByteStrategyElevatedCount(id, qname, qtype, opt_rdata, padding_strategy);
-+		break;
-+	case 5:
-+		CompressedStrategy(id, qname, qtype, opt_rdata, padding_strategy);
-+		break;
-+	default:
-+		UnmodifiedStrategy(id, qname, qtype, opt_rdata, padding_strategy);
-+  }
-+
-+  //CompressedStrategy(id, qname, qtype, opt_rdata, padding_strategy);
-+  //MultiByteStrategyElevatedCount(id, qname, qtype, opt_rdata, padding_strategy);
-+  //MultiByteStrategy(id, qname, qtype, opt_rdata, padding_strategy);
-+  //TruncatedReservedStrategy(id, qname, qtype, opt_rdata, padding_strategy);
-+  //ElevatedCountStrategy(id, qname, qtype, opt_rdata, padding_strategy);
-+  
-+  /*
-+  size_t buffer_size = 0;
-+  int strategy = 1;
-+
-+  if (strategy == 1)   void ElevatedCountStrategy(uint16_t id, const base::StringPiece& qname, uint16_t qtype, const OptRecordRdata* opt_rdata = nullptr,
-+           PaddingStrategy padding_strategy = PaddingStrategy::NONE);{
-+	
-+  }
-+
-+  absl::optional<OptRecordRdata> merged_opt_rdata =
-+      AddPaddingIfNecessary(opt_rdata, padding_strategy, buffer_size);
-+  if (merged_opt_rdata)
-+    buffer_size += OptRecordSize(&merged_opt_rdata.value());
-+
-+  */
-+  /*
-+
-+  // original
-+  //size_t buffer_size = kHeaderSize + QuestionSize(qname_size_);
-+  
-+  // Compression, make the second qr say example.com and the first have www.(pointer to example.com)
-+  
-+  size_t buffer_size = kHeaderSize + QuestionSize(6) + QuestionSize(13);
-+  size_t uncompressed_buffer_size = kHeaderSize + QuestionSize(qname_size_);
-+  compressed = true;
-+  
-+
-+  // Long Secondary Query
-+  //buffer_size += QuestionSize(719 * 4 + 1);
-+  
-+
-   absl::optional<OptRecordRdata> merged_opt_rdata =
-       AddPaddingIfNecessary(opt_rdata, padding_strategy, buffer_size);
-   if (merged_opt_rdata)
-@@ -113,20 +446,121 @@ DnsQuery::DnsQuery(uint16_t id,
- 
-   io_buffer_ = base::MakeRefCounted<IOBufferWithSize>(buffer_size);
- 
-+  //Compression
-+  
-+  if (compressed) {
-+     io_buffer_uncompressed = base::MakeRefCounted<IOBufferWithSize>(uncompressed_buffer_size);
-+  }
-+  
-   header_ = reinterpret_cast<dns_protocol::Header*>(io_buffer_->data());
-   *header_ = {};
-   header_->id = base::HostToNet16(id);
+-  std::unique_ptr<OptRecordRdata> merged_opt_rdata =
+-      AddPaddingIfNecessary(opt_rdata, padding_strategy, buffer_size);
+-  if (merged_opt_rdata)
+-    buffer_size += OptRecordSize(merged_opt_rdata.get());
+-
+-  io_buffer_ = base::MakeRefCounted<IOBufferWithSize>(buffer_size);
+-
+-  header_ = reinterpret_cast<dns_protocol::Header*>(io_buffer_->data());
+-  *header_ = {};
+-  header_->id = base::HostToNet16(id);
 -  header_->flags = base::HostToNet16(dns_protocol::kFlagRD);
 -  header_->qdcount = base::HostToNet16(1);
-+  
- 
-+  //Originally, RD is the only flag set, and nscount is not 1
-+  header_->flags = base::HostToNet16(dns_protocol::kFlagRD);
-+  
-+  
-+  // [breakerspace] Truncated-Reserved, set nscount, z, and tc to 1
-+  // For the Truncated+Reserved strategy, this could be:
-+  //	 ancount >= 1
-+  //     arcount >= 1
-+  //     nscount >= 1
-+  //     qdcount >= 2
-+  uint16_t new_flags = dns_protocol::kFlagRD;
-+  // [breakerspace] 0x40 = 0b1000000, setting z to 1.
-+  new_flags |= 0x40;
-+  // [breakerspace] setting tc to 1
-+  new_flags |= dns_protocol::kFlagTC;
-+  // [breakerspace] changing header_ flag field  
-+  header_->flags = base::HostToNet16(new_flags); 
-+  VLOG(1) << "[breakerspace] FLAGS = " << new_flags;
-+ 
-+
-+  //header_->nscount = base::HostToNet16(1);
-+  //header_->qdcount = base::HostToNet16(2);
-+  //header_->ancount = base::HostToNet16(1);
-+  
-+  */
-+
-+  /*
-+
-+  // Originally, the QDCount is set to 1
-+  //header_->qdcount = base::HostToNet16(1);
-+
-+  // [breakerspace] Elevated Count, set qdcount to 2
-+  header_->qdcount = base::HostToNet16(2);
-+  
-   // Write question section after the header.
-   base::BigEndianWriter writer(io_buffer_->data() + kHeaderSize,
-                                io_buffer_->size() - kHeaderSize);
+-
+-  // Write question section after the header.
+-  base::BigEndianWriter writer(io_buffer_->data() + kHeaderSize,
+-                               io_buffer_->size() - kHeaderSize);
 -  writer.WriteBytes(qname.data(), qname.size());
-+  
-+  //Originally, the qname is written
-+  //writer.WriteBytes(qname.data(), qname.size());
-+  //writer.WriteU16(qtype);
-+  //writer.WriteU16(dns_protocol::kClassIN);
+-  writer.WriteU16(qtype);
+-  writer.WriteU16(dns_protocol::kClassIN);
+-
+-  if (merged_opt_rdata) {
+-    DCHECK_NE(merged_opt_rdata->OptCount(), 0u);
+-
+-    header_->arcount = base::HostToNet16(1);
+-    // Write OPT pseudo-resource record.
+-    writer.WriteU8(0);                       // empty domain name (root domain)
+-    writer.WriteU16(OptRecordRdata::kType);  // type
+-    writer.WriteU16(kMaxUdpPayloadSize);     // class
+-    // ttl (next 3 fields)
+-    writer.WriteU8(0);  // rcode does not apply to requests
+-    writer.WriteU8(0);  // version
+-    // TODO(robpercival): Set "DNSSEC OK" flag if/when DNSSEC is supported:
+-    // https://tools.ietf.org/html/rfc3225#section-3
+-    writer.WriteU16(0);  // flags
+-
+-    // rdata
+-    writer.WriteU16(merged_opt_rdata->buf().size());  // rdata length
+-    writer.WriteBytes(merged_opt_rdata->buf().data(),
+-                      merged_opt_rdata->buf().size());
++  VLOG(1) << "[breakerspace] DnsQuery::DnsQuery()";
 +
-+  VLOG(1) << "[breakerspace] qname.data(): " << qname.data();
-+  VLOG(1) << "[breakerspace] qname.data()[0]: " << int(qname.data()[0]);
-+  VLOG(1) << "[breakerspace] qname.data()[4]: " << int(qname.data()[4]);
-+
-+  
-+  unsigned char example_com_arr[13] = {7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0};
-+  
-+  unsigned char www_arr[6] = {3, 'w', 'w', 'w', 192, 22};
-+  
-+  
-+  writer.WriteBytes(www_arr, 6);
-+  writer.WriteU16(qtype);
-+  writer.WriteU16(dns_protocol::kClassIN);
-+  
-+  writer.WriteBytes(example_com_arr, 13);
-+  writer.WriteU16(qtype);
-+  writer.WriteU16(dns_protocol::kClassIN);
-+  
-+  
-+  if (compressed) {
-+     
-+     dns_protocol::Header* header_uncompressed;
-+     header_uncompressed = reinterpret_cast<dns_protocol::Header*>(io_buffer_uncompressed->data());
-+     *header_uncompressed = {};
-+     header_uncompressed->id = base::HostToNet16(id);
-+     header_->flags = base::HostToNet16(dns_protocol::kFlagRD);
-+     header_uncompressed->qdcount = base::HostToNet16(2);
-+    
-+     VLOG(1) << "[breakerspace] qname.data() = " << qname.data(); 
-+     base::BigEndianWriter uncompressed_writer(io_buffer_uncompressed->data() + kHeaderSize,
-+		     				io_buffer_uncompressed->size() - kHeaderSize);
-+     uncompressed_writer.WriteBytes(qname.data(), qname.size());
-+     uncompressed_writer.WriteU16(qtype);
-+     uncompressed_writer.WriteU16(dns_protocol::kClassIN);
-+
-+  }
-+
-+  
-+
-+   Long Secondary Query
-+   unsigned char multibyte_data[719 * 2 + 1];
-+  //[breakerspace] Might not need to do length octet?
-+  //multibyte_data[0] = 1334 * 2 + 2;
-+  multibyte_data[719 * 2] = 0;
-+
-+  //for(int i = 1; i < (1334 * 2 + 2) - 1; i+=2){
-+  for(int i = 0; i < 719 * 2; i+=2){
-+      multibyte_data[i] = 0xc2;
-+      multibyte_data[i + 1] = 0xa4;
-+  }
-+  writer.WriteBytes(multibyte_data, 719 * 2);
-+  writer.WriteBytes(multibyte_data, 719 * 2 + 1);
-+  
-   writer.WriteU16(qtype);
-   writer.WriteU16(dns_protocol::kClassIN);
-+  */
- 
-+/*
-   if (merged_opt_rdata) {
-+    
-+    VLOG(1) << "[breakerspace] merged_opt_rdata";
-     DCHECK(!merged_opt_rdata.value().opts().empty());
- 
-     header_->arcount = base::HostToNet16(1);
-@@ -146,6 +580,11 @@ DnsQuery::DnsQuery(uint16_t id,
-     writer.WriteBytes(merged_opt_rdata.value().buf().data(),
-                       merged_opt_rdata.value().buf().size());
++  switch (strategy) {
++   case 1:
++       ElevatedCountStrategy(id, qname, qtype, opt_rdata, padding_strategy);
++       break;
++   case 2:
++       TruncatedReservedStrategy(id, qname, qtype, opt_rdata, padding_strategy);
++       break;
++   case 3:
++       MultiByteStrategy(id, qname, qtype, opt_rdata, padding_strategy);
++       break;
++   case 4:
++       MultiByteStrategyElevatedCount(id, qname, qtype, opt_rdata, padding_strategy);
++       break;
++   case 5:
++       CompressedStrategy(id, qname, qtype, opt_rdata, padding_strategy);
++       break;
++   default:
++       UnmodifiedStrategy(id, qname, qtype, opt_rdata, padding_strategy);
    }
-+  */
-+}
-+
-+bool DnsQuery::is_compressed() const{	
-+  return compressed;
  }
  
++bool DnsQuery::is_compressed() const{	
++  return compressed;
++}
++
  DnsQuery::DnsQuery(scoped_refptr<IOBufferWithSize> buffer)
-@@ -163,10 +602,12 @@ DnsQuery& DnsQuery::operator=(const DnsQuery& query) {
+     : io_buffer_(std::move(buffer)) {}
+ 
+@@ -169,10 +415,12 @@ DnsQuery& DnsQuery::operator=(const DnsQuery& query) {
  DnsQuery::~DnsQuery() = default;
  
  std::unique_ptr<DnsQuery> DnsQuery::CloneWithNewId(uint16_t id) const {
@@ -938,7 +793,7 @@ index 75faae360b472..ae9a86f18ffab 100644
    if (io_buffer_ == nullptr || io_buffer_->data() == nullptr) {
      return false;
    }
-@@ -184,11 +625,18 @@ bool DnsQuery::Parse(size_t valid_bytes) {
+@@ -190,11 +438,18 @@ bool DnsQuery::Parse(size_t valid_bytes) {
    if (header.flags & dns_protocol::kFlagResponse) {
      return false;
    }
@@ -957,7 +812,7 @@ index 75faae360b472..ae9a86f18ffab 100644
    std::string qname;
    if (!ReadName(&reader, &qname)) {
      return false;
-@@ -211,20 +659,37 @@ uint16_t DnsQuery::id() const {
+@@ -217,20 +472,37 @@ uint16_t DnsQuery::id() const {
  }
  
  base::StringPiece DnsQuery::qname() const {
@@ -999,7 +854,7 @@ index 75faae360b472..ae9a86f18ffab 100644
  }
  
  size_t DnsQuery::question_size() const {
-@@ -232,24 +697,37 @@ size_t DnsQuery::question_size() const {
+@@ -238,24 +510,37 @@ size_t DnsQuery::question_size() const {
  }
  
  void DnsQuery::set_flags(uint16_t flags) {
@@ -1037,7 +892,7 @@ index 75faae360b472..ae9a86f18ffab 100644
    return (
        reader->ReadU16(&header->id) && reader->ReadU16(&header->flags) &&
        reader->ReadU16(&header->qdcount) && reader->ReadU16(&header->ancount) &&
-@@ -258,6 +736,7 @@ bool DnsQuery::ReadHeader(base::BigEndianReader* reader,
+@@ -264,6 +549,7 @@ bool DnsQuery::ReadHeader(base::BigEndianReader* reader,
  
  bool DnsQuery::ReadName(base::BigEndianReader* reader, std::string* out) {
    DCHECK(out != nullptr);
@@ -1045,14 +900,14 @@ index 75faae360b472..ae9a86f18ffab 100644
    out->clear();
    out->reserve(dns_protocol::kMaxNameLength + 1);
    uint8_t label_length;
-@@ -285,4 +764,4 @@ bool DnsQuery::ReadName(base::BigEndianReader* reader, std::string* out) {
+@@ -291,4 +577,4 @@ bool DnsQuery::ReadName(base::BigEndianReader* reader, std::string* out) {
    return true;
  }
  
 -}  // namespace net
 +} // namespace net
 diff --git a/net/dns/dns_query.h b/net/dns/dns_query.h
-index 6a9db0971bad1..1c2bb0c4bb508 100644
+index 7e2045d0e07ed..3149d51cf2d1f 100644
 --- a/net/dns/dns_query.h
 +++ b/net/dns/dns_query.h
 @@ -14,6 +14,8 @@
@@ -1102,7 +957,7 @@ index 6a9db0971bad1..1c2bb0c4bb508 100644
 +
 +  void CreateIOBufferAndHeader(uint16_t id, const base::StringPiece& qname, uint16_t qtype, size_t size);
 +
-+  void AddPadding(absl::optional<OptRecordRdata>* merged_opt_rdata, base::BigEndianWriter* writer); 
++  void AddPadding(std::unique_ptr<OptRecordRdata>* merged_opt_rdata, base::BigEndianWriter* writer); 
 +
    bool ReadHeader(base::BigEndianReader* reader, dns_protocol::Header* out);
    // After read, |out| is in the DNS format, e.g.
@@ -1125,7 +980,7 @@ index 6a9db0971bad1..1c2bb0c4bb508 100644
  
  }  // namespace net
 diff --git a/net/dns/dns_response.cc b/net/dns/dns_response.cc
-index 762521d0691b8..488e1d73f6946 100644
+index d1f1ef7eb7e84..0a45d674426ea 100644
 --- a/net/dns/dns_response.cc
 +++ b/net/dns/dns_response.cc
 @@ -277,6 +277,7 @@ DnsResponse::DnsResponse(
@@ -1136,7 +991,7 @@ index 762521d0691b8..488e1d73f6946 100644
    dns_protocol::Header header;
    header.id = id;
    bool success = true;
-@@ -353,14 +354,14 @@ DnsResponse::DnsResponse(
+@@ -352,14 +353,14 @@ DnsResponse::DnsResponse(
  
  DnsResponse::DnsResponse()
      : io_buffer_(base::MakeRefCounted<IOBuffer>(dns_protocol::kMaxUDPSize + 1)),
@@ -1154,7 +1009,7 @@ index 762521d0691b8..488e1d73f6946 100644
  
  DnsResponse::DnsResponse(const void* data, size_t length, size_t answer_offset)
      : io_buffer_(base::MakeRefCounted<IOBufferWithSize>(length)),
-@@ -369,6 +370,7 @@ DnsResponse::DnsResponse(const void* data, size_t length, size_t answer_offset)
+@@ -368,6 +369,7 @@ DnsResponse::DnsResponse(const void* data, size_t length, size_t answer_offset)
                length,
                answer_offset,
                std::numeric_limits<size_t>::max()) {
@@ -1162,7 +1017,7 @@ index 762521d0691b8..488e1d73f6946 100644
    DCHECK(data);
    memcpy(io_buffer_->data(), data, length);
  }
-@@ -391,10 +393,11 @@ DnsResponse::~DnsResponse() = default;
+@@ -390,10 +392,11 @@ DnsResponse::~DnsResponse() = default;
  
  bool DnsResponse::InitParse(size_t nbytes, const DnsQuery& query) {
    const base::StringPiece question = query.question();
@@ -1176,7 +1031,7 @@ index 762521d0691b8..488e1d73f6946 100644
    }
  
    // At this point, it has been validated that the response is at least large
-@@ -411,18 +414,61 @@ bool DnsResponse::InitParse(size_t nbytes, const DnsQuery& query) {
+@@ -410,18 +413,61 @@ bool DnsResponse::InitParse(size_t nbytes, const DnsQuery& query) {
      return false;
  
    // Match question count.
@@ -1239,7 +1094,7 @@ index 762521d0691b8..488e1d73f6946 100644
    dotted_qnames_.push_back(std::move(dotted_qname).value());
    qtypes_.push_back(query.qtype());
  
-@@ -495,6 +541,7 @@ uint8_t DnsResponse::rcode() const {
+@@ -494,6 +540,7 @@ uint8_t DnsResponse::rcode() const {
  
  unsigned DnsResponse::question_count() const {
    DCHECK(parser_.IsValid());
@@ -1248,10 +1103,10 @@ index 762521d0691b8..488e1d73f6946 100644
  }
  
 diff --git a/net/dns/dns_test_util.cc b/net/dns/dns_test_util.cc
-index 0f07bb3dd8437..9fc7c9e327eb5 100644
+index 8dc388806b0ae..e52faa5151c25 100644
 --- a/net/dns/dns_test_util.cc
 +++ b/net/dns/dns_test_util.cc
-@@ -494,6 +494,8 @@ class MockDnsTransactionFactory::MockTransaction
+@@ -491,6 +491,8 @@ class MockDnsTransactionFactory::MockTransaction
  
    uint16_t GetType() const override { return qtype_; }
  
@@ -1261,10 +1116,10 @@ index 0f07bb3dd8437..9fc7c9e327eb5 100644
      CHECK(!callback.is_null());
      CHECK(callback_.is_null());
 diff --git a/net/dns/dns_transaction.cc b/net/dns/dns_transaction.cc
-index 0a07cccaf4dab..2087a0b0debe8 100644
+index 0c03aa3d6dcda..f9b255ffef5a5 100644
 --- a/net/dns/dns_transaction.cc
 +++ b/net/dns/dns_transaction.cc
-@@ -220,6 +220,7 @@ class DnsUDPAttempt : public DnsAttempt {
+@@ -216,6 +216,7 @@ class DnsUDPAttempt : public DnsAttempt {
      start_time_ = base::TimeTicks::Now();
      next_state_ = STATE_SEND_QUERY;
  
@@ -1272,7 +1127,7 @@ index 0a07cccaf4dab..2087a0b0debe8 100644
      int rv = socket_->Connect(server_);
      if (rv != OK) {
        DVLOG(1) << "Failed to connect socket: " << rv;
-@@ -234,7 +235,7 @@ class DnsUDPAttempt : public DnsAttempt {
+@@ -230,7 +231,7 @@ class DnsUDPAttempt : public DnsAttempt {
      return DoLoop(OK);
    }
  
@@ -1281,7 +1136,7 @@ index 0a07cccaf4dab..2087a0b0debe8 100644
  
    const DnsResponse* GetResponse() const override {
      const DnsResponse* resp = response_.get();
-@@ -297,6 +298,7 @@ class DnsUDPAttempt : public DnsAttempt {
+@@ -291,6 +292,7 @@ class DnsUDPAttempt : public DnsAttempt {
  
    int DoSendQuery() {
      next_state_ = STATE_SEND_QUERY_COMPLETE;
@@ -1289,7 +1144,7 @@ index 0a07cccaf4dab..2087a0b0debe8 100644
      return socket_->Write(
          query_->io_buffer(), query_->io_buffer()->size(),
          base::BindOnce(&DnsUDPAttempt::OnIOComplete, base::Unretained(this)),
-@@ -305,6 +307,7 @@ class DnsUDPAttempt : public DnsAttempt {
+@@ -299,6 +301,7 @@ class DnsUDPAttempt : public DnsAttempt {
  
    int DoSendQueryComplete(int rv) {
      DCHECK_NE(ERR_IO_PENDING, rv);
@@ -1297,7 +1152,7 @@ index 0a07cccaf4dab..2087a0b0debe8 100644
      if (rv < 0)
        return rv;
  
-@@ -317,6 +320,7 @@ class DnsUDPAttempt : public DnsAttempt {
+@@ -311,6 +314,7 @@ class DnsUDPAttempt : public DnsAttempt {
    }
  
    int DoReadResponse() {
@@ -1305,7 +1160,7 @@ index 0a07cccaf4dab..2087a0b0debe8 100644
      next_state_ = STATE_READ_RESPONSE_COMPLETE;
      response_ = std::make_unique<DnsResponse>();
      return socket_->Read(
-@@ -325,7 +329,9 @@ class DnsUDPAttempt : public DnsAttempt {
+@@ -319,7 +323,9 @@ class DnsUDPAttempt : public DnsAttempt {
    }
  
    int DoReadResponseComplete(int rv) {
@@ -1314,8 +1169,8 @@ index 0a07cccaf4dab..2087a0b0debe8 100644
 +    VLOG(1) << "[breakerspace] DnsUDPAttempt::DoReadResponseComplete(), rv = " << rv;
      if (rv < 0)
        return rv;
- 
-@@ -347,6 +353,7 @@ class DnsUDPAttempt : public DnsAttempt {
+     read_size_ = rv;
+@@ -342,6 +348,7 @@ class DnsUDPAttempt : public DnsAttempt {
    }
  
    void OnIOComplete(int rv) {
@@ -1323,16 +1178,7 @@ index 0a07cccaf4dab..2087a0b0debe8 100644
      rv = DoLoop(rv);
      if (rv != ERR_IO_PENDING)
        std::move(callback_).Run(rv);
-@@ -1127,7 +1134,7 @@ class DnsTransactionImpl : public DnsTransaction,
-         attempts_count_(0),
-         had_tcp_retry_(false),
-         resolve_context_(resolve_context->AsSafeRef()),
--        request_priority_(DEFAULT_PRIORITY) {
-+        request_priority_(DEFAULT_PRIORITY){
-     DCHECK(session_.get());
-     DCHECK(!hostname_.empty());
-     DCHECK(!IsIPLiteral(hostname_));
-@@ -1159,6 +1166,8 @@ class DnsTransactionImpl : public DnsTransaction,
+@@ -1146,6 +1153,8 @@ class DnsTransactionImpl : public DnsTransaction,
      DCHECK(callback_.is_null());
      DCHECK(attempts_.empty());
  
@@ -1341,7 +1187,7 @@ index 0a07cccaf4dab..2087a0b0debe8 100644
      callback_ = std::move(callback);
  
      net_log_.BeginEvent(NetLogEventType::DNS_TRANSACTION,
-@@ -1185,6 +1194,10 @@ class DnsTransactionImpl : public DnsTransaction,
+@@ -1172,6 +1181,10 @@ class DnsTransactionImpl : public DnsTransaction,
      request_priority_ = priority;
    }
  
@@ -1352,7 +1198,7 @@ index 0a07cccaf4dab..2087a0b0debe8 100644
   private:
    // Wrapper for the result of a DnsUDPAttempt.
    struct AttemptResult {
-@@ -1209,6 +1222,7 @@ class DnsTransactionImpl : public DnsTransaction,
+@@ -1196,6 +1209,7 @@ class DnsTransactionImpl : public DnsTransaction,
    int PrepareSearch() {
      const DnsConfig& config = session_->config();
  
@@ -1360,7 +1206,7 @@ index 0a07cccaf4dab..2087a0b0debe8 100644
      std::string labeled_hostname;
      if (!DNSDomainFromDot(hostname_, &labeled_hostname))
        return ERR_INVALID_ARGUMENT;
-@@ -1303,8 +1317,10 @@ class DnsTransactionImpl : public DnsTransaction,
+@@ -1283,8 +1297,10 @@ class DnsTransactionImpl : public DnsTransaction,
      uint16_t id = session_->NextQueryId();
      std::unique_ptr<DnsQuery> query;
      if (attempts_.empty()) {
@@ -1372,7 +1218,7 @@ index 0a07cccaf4dab..2087a0b0debe8 100644
      } else {
        query = attempts_[0]->GetQuery()->CloneWithNewId(id);
      }
-@@ -1339,10 +1355,13 @@ class DnsTransactionImpl : public DnsTransaction,
+@@ -1319,10 +1335,13 @@ class DnsTransactionImpl : public DnsTransaction,
      DCHECK(!secure_);
      DCHECK(!session_->udp_tracker()->low_entropy());
  
@@ -1386,8 +1232,8 @@ index 0a07cccaf4dab..2087a0b0debe8 100644
      std::unique_ptr<DatagramClientSocket> socket =
          resolve_context_->url_request_context()
              ->GetNetworkSessionContext()
-@@ -1709,6 +1728,9 @@ class DnsTransactionImpl : public DnsTransaction,
-   RequestPriority request_priority_;
+@@ -1688,6 +1707,9 @@ class DnsTransactionImpl : public DnsTransaction,
+   RequestPriority request_priority_ = DEFAULT_PRIORITY;
  
    THREAD_CHECKER(thread_checker_);
 +
@@ -1396,7 +1242,7 @@ index 0a07cccaf4dab..2087a0b0debe8 100644
  };
  
  // ----------------------------------------------------------------------------
-@@ -1719,6 +1741,7 @@ class DnsTransactionFactoryImpl : public DnsTransactionFactory {
+@@ -1698,6 +1720,7 @@ class DnsTransactionFactoryImpl : public DnsTransactionFactory {
   public:
    explicit DnsTransactionFactoryImpl(DnsSession* session) {
      session_ = session;
@@ -1404,7 +1250,7 @@ index 0a07cccaf4dab..2087a0b0debe8 100644
    }
  
    std::unique_ptr<DnsTransaction> CreateTransaction(
-@@ -1729,7 +1752,9 @@ class DnsTransactionFactoryImpl : public DnsTransactionFactory {
+@@ -1708,7 +1731,9 @@ class DnsTransactionFactoryImpl : public DnsTransactionFactory {
        SecureDnsMode secure_dns_mode,
        ResolveContext* resolve_context,
        bool fast_timeout) override {
@@ -1415,20 +1261,19 @@ index 0a07cccaf4dab..2087a0b0debe8 100644
          session_.get(), std::move(hostname), qtype, net_log, opt_rdata_.get(),
          secure, secure_dns_mode, resolve_context, fast_timeout);
    }
-@@ -1764,6 +1789,8 @@ DnsTransactionFactory::~DnsTransactionFactory() = default;
+@@ -1744,6 +1769,7 @@ DnsTransactionFactory::~DnsTransactionFactory() = default;
  // static
  std::unique_ptr<DnsTransactionFactory> DnsTransactionFactory::CreateFactory(
      DnsSession* session) {
-+
 +  VLOG(1) << "[breakerspace] (static) DnsTransactionFactory::CreateFactory()";
-   return std::unique_ptr<DnsTransactionFactory>(
-       new DnsTransactionFactoryImpl(session));
+   return std::make_unique<DnsTransactionFactoryImpl>(session);
  }
+ 
 diff --git a/net/dns/dns_transaction.h b/net/dns/dns_transaction.h
-index a8d199bf74f35..26965a7047106 100644
+index c388ff8a3098b..c996a51e3ce13 100644
 --- a/net/dns/dns_transaction.h
 +++ b/net/dns/dns_transaction.h
-@@ -59,6 +59,9 @@ class NET_EXPORT_PRIVATE DnsTransaction {
+@@ -58,6 +58,9 @@ class NET_EXPORT_PRIVATE DnsTransaction {
    virtual void Start(ResponseCallback callback) = 0;
  
    virtual void SetRequestPriority(RequestPriority priority) = 0;
@@ -1439,10 +1284,10 @@ index a8d199bf74f35..26965a7047106 100644
  
  // Startable/Cancellable object to represent a DNS probe sequence.
 diff --git a/net/dns/host_resolver.cc b/net/dns/host_resolver.cc
-index b148c4c6af2da..1da73f981ac07 100644
+index b9325a9173830..0011291906b60 100644
 --- a/net/dns/host_resolver.cc
 +++ b/net/dns/host_resolver.cc
-@@ -108,6 +108,8 @@ std::unique_ptr<HostResolver> HostResolver::Factory::CreateResolver(
+@@ -207,6 +207,8 @@ std::unique_ptr<HostResolver> HostResolver::Factory::CreateResolver(
      HostResolverManager* manager,
      base::StringPiece host_mapping_rules,
      bool enable_caching) {
@@ -1451,7 +1296,7 @@ index b148c4c6af2da..1da73f981ac07 100644
    return HostResolver::CreateResolver(manager, host_mapping_rules,
                                        enable_caching);
  }
-@@ -128,6 +130,10 @@ HostResolver::ResolveHostParameters::ResolveHostParameters(
+@@ -227,6 +229,10 @@ HostResolver::ResolveHostParameters::ResolveHostParameters(
  
  HostResolver::~HostResolver() = default;
  
@@ -1462,7 +1307,7 @@ index b148c4c6af2da..1da73f981ac07 100644
  std::unique_ptr<HostResolver::ProbeRequest>
  HostResolver::CreateDohProbeRequest() {
    // Should be overridden in any HostResolver implementation where this method
-@@ -178,6 +184,8 @@ std::unique_ptr<HostResolver> HostResolver::CreateResolver(
+@@ -281,6 +287,8 @@ std::unique_ptr<HostResolver> HostResolver::CreateResolver(
      HostResolverManager* manager,
      base::StringPiece host_mapping_rules,
      bool enable_caching) {
@@ -1472,10 +1317,10 @@ index b148c4c6af2da..1da73f981ac07 100644
  
    auto resolve_context = std::make_unique<ResolveContext>(
 diff --git a/net/dns/host_resolver.h b/net/dns/host_resolver.h
-index dbaec0764826d..796bce3d76ce7 100644
+index bbe3888c28ac8..18ee9c29738b6 100644
 --- a/net/dns/host_resolver.h
 +++ b/net/dns/host_resolver.h
-@@ -192,7 +192,9 @@ class NET_EXPORT HostResolver {
+@@ -226,7 +226,9 @@ class NET_EXPORT HostResolver {
      // Initial setting for whether the insecure portion of the built-in
      // asynchronous DnsClient is enabled or disabled. See HostResolverManager::
      // SetInsecureDnsClientEnabled() for details.
@@ -1486,9 +1331,9 @@ index dbaec0764826d..796bce3d76ce7 100644
  
      // Initial setting for whether additional DNS types (e.g. HTTPS) may be
      // queried when using the built-in resolver for insecure DNS.
-@@ -459,6 +461,9 @@ class NET_EXPORT HostResolver {
-       const std::vector<HostResolverEndpointResult>& endpoints,
-       const std::set<std::string>& aliases);
+@@ -504,6 +506,9 @@ class NET_EXPORT HostResolver {
+   static std::vector<IPEndPoint> GetNonProtocolEndpoints(
+       const std::vector<HostResolverEndpointResult>& endpoints);
  
 + // [breakerspace]
 + virtual void SetStrategyInManager(unsigned int packet_strategy);
@@ -1497,10 +1342,10 @@ index dbaec0764826d..796bce3d76ce7 100644
    HostResolver();
  
 diff --git a/net/dns/host_resolver_manager.cc b/net/dns/host_resolver_manager.cc
-index 207b769273fcc..4922b3a09b511 100644
+index 066fd3fa9942e..78c26faf534cd 100644
 --- a/net/dns/host_resolver_manager.cc
 +++ b/net/dns/host_resolver_manager.cc
-@@ -644,6 +644,8 @@ class HostResolverManager::RequestImpl
+@@ -643,6 +643,8 @@ class HostResolverManager::RequestImpl
      // Parent HostResolver must still be alive to call Start().
      DCHECK(resolver_);
  
@@ -1509,7 +1354,7 @@ index 207b769273fcc..4922b3a09b511 100644
      if (!resolve_context_) {
        complete_ = true;
        resolver_.reset();
-@@ -1054,6 +1056,7 @@ class HostResolverManager::ProcTask {
+@@ -1034,6 +1036,7 @@ class HostResolverManager::ProcTask {
    }
  
    void Start() {
@@ -1517,31 +1362,31 @@ index 207b769273fcc..4922b3a09b511 100644
      DCHECK(network_task_runner_->BelongsToCurrentThread());
      DCHECK(!was_completed());
      net_log_.BeginEvent(NetLogEventType::HOST_RESOLVER_MANAGER_PROC_TASK);
-@@ -1261,7 +1264,8 @@ class HostResolverManager::DnsTask : public base::SupportsWeakPtr<DnsTask> {
-           Delegate* delegate,
+@@ -1242,7 +1245,8 @@ class HostResolverManager::DnsTask : public base::SupportsWeakPtr<DnsTask> {
            const NetLogWithSource& job_net_log,
            const base::TickClock* tick_clock,
--          bool fallback_available)
-+          bool fallback_available,
-+	  unsigned int packet_strategy = 0)
+           bool fallback_available,
+-          const HostResolver::HttpsSvcbOptions& https_svcb_options)
++          const HostResolver::HttpsSvcbOptions& https_svcb_options,
++          unsigned int packet_strategy = 0)
        : client_(client),
          host_(std::move(host)),
          resolve_context_(resolve_context->AsSafeRef()),
-@@ -1271,10 +1275,12 @@ class HostResolverManager::DnsTask : public base::SupportsWeakPtr<DnsTask> {
-         net_log_(job_net_log),
+@@ -1253,10 +1257,12 @@ class HostResolverManager::DnsTask : public base::SupportsWeakPtr<DnsTask> {
          tick_clock_(tick_clock),
          task_start_time_(tick_clock_->NowTicks()),
--        fallback_available_(fallback_available) {
-+        fallback_available_(fallback_available),
-+       	strategy(packet_strategy)	{
+         fallback_available_(fallback_available),
+-        https_svcb_options_(https_svcb_options) {
++        https_svcb_options_(https_svcb_options),
++        strategy(packet_strategy) {
      DCHECK(client_);
      DCHECK(delegate_);
  
 +    VLOG(1) << "[breakerspace] DnsTask::DnsTask()";
-     if (secure_)
-       DCHECK(client_->CanUseSecureDnsTransactions());
-     else
-@@ -1298,7 +1304,7 @@ class HostResolverManager::DnsTask : public base::SupportsWeakPtr<DnsTask> {
+     if (!secure_) {
+       DCHECK(client_->CanUseInsecureDnsTransactions());
+     }
+@@ -1279,7 +1285,7 @@ class HostResolverManager::DnsTask : public base::SupportsWeakPtr<DnsTask> {
  
    void StartNextTransaction() {
      DCHECK_GE(num_additional_transactions_needed(), 1);
@@ -1550,7 +1395,7 @@ index 207b769273fcc..4922b3a09b511 100644
      if (!any_transaction_started_) {
        net_log_.BeginEvent(NetLogEventType::HOST_RESOLVER_MANAGER_DNS_TASK,
                            [&] { return NetLogDnsTaskCreationParams(); });
-@@ -1437,6 +1443,7 @@ class HostResolverManager::DnsTask : public base::SupportsWeakPtr<DnsTask> {
+@@ -1421,6 +1427,7 @@ class HostResolverManager::DnsTask : public base::SupportsWeakPtr<DnsTask> {
    void PushTransactionsNeeded(DnsQueryTypeSet query_types) {
      DCHECK(transactions_needed_.empty());
  
@@ -1558,7 +1403,7 @@ index 207b769273fcc..4922b3a09b511 100644
      if (query_types.Has(DnsQueryType::HTTPS) &&
          features::kUseDnsHttpsSvcbEnforceSecureResponse.Get() && secure_) {
        query_types.Remove(DnsQueryType::HTTPS);
-@@ -1473,6 +1480,7 @@ class HostResolverManager::DnsTask : public base::SupportsWeakPtr<DnsTask> {
+@@ -1457,6 +1464,7 @@ class HostResolverManager::DnsTask : public base::SupportsWeakPtr<DnsTask> {
      DCHECK_NE(DnsQueryType::UNSPECIFIED, transaction_info.type);
  
      std::string transaction_hostname(GetHostname(host_));
@@ -1566,7 +1411,7 @@ index 207b769273fcc..4922b3a09b511 100644
  
      // For HTTPS, prepend "_<port>._https." for any non-default port.
      uint16_t request_port = 0;
-@@ -1489,6 +1497,9 @@ class HostResolverManager::DnsTask : public base::SupportsWeakPtr<DnsTask> {
+@@ -1473,6 +1481,9 @@ class HostResolverManager::DnsTask : public base::SupportsWeakPtr<DnsTask> {
              DnsQueryTypeToQtype(transaction_info.type), net_log_, secure_,
              secure_dns_mode_, &*resolve_context_,
              fallback_available_ /* fast_timeout */);
@@ -1576,28 +1421,28 @@ index 207b769273fcc..4922b3a09b511 100644
      transaction_info.transaction->SetRequestPriority(delegate_->priority());
  
      auto transaction_info_it =
-@@ -2110,6 +2121,9 @@ class HostResolverManager::DnsTask : public base::SupportsWeakPtr<DnsTask> {
-   // task completes unsuccessfully. Used as a signal that underlying
-   // transactions should timeout more quickly.
+@@ -2075,6 +2086,9 @@ class HostResolverManager::DnsTask : public base::SupportsWeakPtr<DnsTask> {
    bool fallback_available_;
+ 
+   const HostResolver::HttpsSvcbOptions https_svcb_options_;
 +
 +  // [breakerspace]
 +  unsigned int strategy;
  };
  
  //-----------------------------------------------------------------------------
-@@ -2182,7 +2196,8 @@ class HostResolverManager::Job : public PrioritizedDispatcher::Job,
-       RequestPriority priority,
+@@ -2148,7 +2162,8 @@ class HostResolverManager::Job : public PrioritizedDispatcher::Job,
        scoped_refptr<base::TaskRunner> proc_task_runner,
        const NetLogWithSource& source_net_log,
--      const base::TickClock* tick_clock)
-+      const base::TickClock* tick_clock,
+       const base::TickClock* tick_clock,
+-      const HostResolver::HttpsSvcbOptions& https_svcb_options)
++      const HostResolver::HttpsSvcbOptions& https_svcb_options,
 +      /* [breakerspace] */ unsigned int packet_strategy = 0)
        : resolver_(resolver),
          key_(std::move(key)),
          cache_usage_(cache_usage),
-@@ -2193,9 +2208,10 @@ class HostResolverManager::Job : public PrioritizedDispatcher::Job,
-         tick_clock_(tick_clock),
+@@ -2160,9 +2175,10 @@ class HostResolverManager::Job : public PrioritizedDispatcher::Job,
+         https_svcb_options_(https_svcb_options),
          net_log_(
              NetLogWithSource::Make(source_net_log.net_log(),
 -                                   NetLogSourceType::HOST_RESOLVER_IMPL_JOB)) {
@@ -1609,7 +1454,7 @@ index 207b769273fcc..4922b3a09b511 100644
      net_log_.BeginEvent(NetLogEventType::HOST_RESOLVER_MANAGER_JOB, [&] {
        return NetLogJobCreationParams(source_net_log.source());
      });
-@@ -2226,6 +2242,11 @@ class HostResolverManager::Job : public PrioritizedDispatcher::Job,
+@@ -2193,6 +2209,11 @@ class HostResolverManager::Job : public PrioritizedDispatcher::Job,
      }
    }
  
@@ -1621,7 +1466,7 @@ index 207b769273fcc..4922b3a09b511 100644
    // Add this job to the dispatcher.  If "at_head" is true, adds at the front
    // of the queue.
    void Schedule(bool at_head) {
-@@ -2407,9 +2428,12 @@ class HostResolverManager::Job : public PrioritizedDispatcher::Job,
+@@ -2374,9 +2395,12 @@ class HostResolverManager::Job : public PrioritizedDispatcher::Job,
    }
  
    void RunNextTask() {
@@ -1634,20 +1479,16 @@ index 207b769273fcc..4922b3a09b511 100644
      if (tasks_.empty()) {
        // If there are no stored results, complete with an error.
        if (completion_results_.size() == 0) {
-@@ -2675,10 +2699,11 @@ class HostResolverManager::Job : public PrioritizedDispatcher::Job,
-     DCHECK(!resolver_->ShouldForceSystemResolverDueToTestOverride());
-     // Need to create the task even if we're going to post a failure instead of
-     // running it, as a "started" job needs a task to be properly cleaned up.
-+    VLOG(1) << "[breakerspace] Job::StartDnsTask()";
-     dns_task_ = std::make_unique<DnsTask>(
+@@ -2657,7 +2681,7 @@ class HostResolverManager::Job : public PrioritizedDispatcher::Job,
          resolver_->dns_client_.get(), key_.host, key_.query_types,
          &*key_.resolve_context, secure, key_.secure_dns_mode, this, net_log_,
--        tick_clock_, !tasks_.empty() /* fallback_available */);
-+        tick_clock_, !tasks_.empty() /* fallback_available */, /* [breakerspace] */ strategy);
+         tick_clock_, !tasks_.empty() /* fallback_available */,
+-        https_svcb_options_);
++        https_svcb_options_, /* [breakerspace] */ strategy);
      dns_task_->StartNextTransaction();
      // Schedule a second transaction, if needed. DoH queries can bypass the
      // dispatcher and start all of their transactions immediately.
-@@ -3096,12 +3121,18 @@ class HostResolverManager::Job : public PrioritizedDispatcher::Job,
+@@ -3072,12 +3096,18 @@ class HostResolverManager::Job : public PrioritizedDispatcher::Job,
    // A handle used for |dispatcher_|.
    PrioritizedDispatcher::Handle handle_;
  
@@ -1666,17 +1507,17 @@ index 207b769273fcc..4922b3a09b511 100644
  };
  
  //-----------------------------------------------------------------------------
-@@ -3227,6 +3258,8 @@ HostResolverManager::CreateRequest(
- 
-   DCHECK_EQ(resolve_context->GetTargetNetwork(), target_network_);
+@@ -3205,6 +3235,8 @@ HostResolverManager::CreateRequest(
+   // ensure cached data is invalidated on network and configuration changes.
+   DCHECK(registered_contexts_.HasObserver(resolve_context));
  
 +  VLOG(1) << "[breakerspace] HostResolverManager::CreateRequest()";
 +
-   // If required, ResolveContexts must register (via RegisterResolveContext())
-   // before use to ensure cached data is invalidated on network and
-   // configuration changes.
-@@ -3239,6 +3272,10 @@ HostResolverManager::CreateRequest(
-       weak_ptr_factory_.GetWeakPtr(), tick_clock_);
+ return std::make_unique<RequestImpl>(std::move(net_log),
+                                      std::move(host),
+                                      std::move(network_anonymization_key),
+@@ -3215,6 +3247,10 @@ return std::make_unique<RequestImpl>(std::move(net_log),
+                                      tick_clock_);
  }
  
 +void HostResolverManager::SetStrategy(unsigned int packet_strategy) {
@@ -1686,7 +1527,7 @@ index 207b769273fcc..4922b3a09b511 100644
  std::unique_ptr<HostResolver::ProbeRequest>
  HostResolverManager::CreateDohProbeRequest(ResolveContext* context) {
    DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-@@ -3434,6 +3471,7 @@ bool HostResolverManager::IsLocalTask(TaskType task) {
+@@ -3387,6 +3423,7 @@ bool HostResolverManager::IsLocalTask(TaskType task) {
  }
  
  int HostResolverManager::Resolve(RequestImpl* request) {
@@ -1694,7 +1535,7 @@ index 207b769273fcc..4922b3a09b511 100644
    DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
    // Request should not yet have a scheduled Job.
    DCHECK(!request->HasJob());
-@@ -3496,7 +3534,7 @@ HostCache::Entry HostResolverManager::ResolveLocally(
+@@ -3450,7 +3487,7 @@ HostCache::Entry HostResolverManager::ResolveLocally(
      absl::optional<HostCache::EntryStaleness>* out_stale_info) {
    DCHECK(out_stale_info);
    *out_stale_info = absl::nullopt;
@@ -1703,7 +1544,7 @@ index 207b769273fcc..4922b3a09b511 100644
    CreateTaskSequence(job_key, cache_usage, secure_dns_policy, out_tasks);
  
    if (!ip_address.IsValid()) {
-@@ -3596,17 +3634,19 @@ void HostResolverManager::CreateAndStartJob(JobKey key,
+@@ -3550,17 +3587,19 @@ void HostResolverManager::CreateAndStartJob(JobKey key,
                                              std::deque<TaskType> tasks,
                                              RequestImpl* request) {
    DCHECK(!tasks.empty());
@@ -1724,15 +1565,15 @@ index 207b769273fcc..4922b3a09b511 100644
      job->AddRequest(request);
    }
  }
-@@ -3887,6 +3927,7 @@ void HostResolverManager::PushDnsTasks(bool proc_task_allowed,
+@@ -3841,6 +3880,7 @@ void HostResolverManager::PushDnsTasks(bool proc_task_allowed,
    // Upgrade the insecure DnsTask depending on the secure dns mode.
    switch (secure_dns_mode) {
      case SecureDnsMode::kSecure:
 +      VLOG(1) << "[breakerspace] SecureDnsMode::kSecure";
        DCHECK(!allow_cache ||
               out_tasks->front() == TaskType::SECURE_CACHE_LOOKUP);
-       DCHECK(dns_client_->CanUseSecureDnsTransactions());
-@@ -3894,6 +3935,7 @@ void HostResolverManager::PushDnsTasks(bool proc_task_allowed,
+       // Policy misconfiguration can put us in secure DNS mode without any DoH
+@@ -3849,6 +3889,7 @@ void HostResolverManager::PushDnsTasks(bool proc_task_allowed,
          out_tasks->push_back(TaskType::SECURE_DNS);
        break;
      case SecureDnsMode::kAutomatic:
@@ -1740,7 +1581,7 @@ index 207b769273fcc..4922b3a09b511 100644
        DCHECK(!allow_cache || out_tasks->front() == TaskType::CACHE_LOOKUP);
        if (dns_client_->FallbackFromSecureTransactionPreferred(
                resolve_context)) {
-@@ -3925,6 +3967,7 @@ void HostResolverManager::PushDnsTasks(bool proc_task_allowed,
+@@ -3880,6 +3921,7 @@ void HostResolverManager::PushDnsTasks(bool proc_task_allowed,
        }
        break;
      case SecureDnsMode::kOff:
@@ -1748,7 +1589,7 @@ index 207b769273fcc..4922b3a09b511 100644
        DCHECK(!allow_cache || IsLocalTask(out_tasks->front()));
        if (dns_tasks_allowed && insecure_tasks_allowed)
          out_tasks->push_back(TaskType::DNS);
-@@ -3951,10 +3994,13 @@ void HostResolverManager::CreateTaskSequence(
+@@ -3906,10 +3948,13 @@ void HostResolverManager::CreateTaskSequence(
      std::deque<TaskType>* out_tasks) {
    DCHECK(out_tasks->empty());
  
@@ -1762,7 +1603,7 @@ index 207b769273fcc..4922b3a09b511 100644
    if (secure_dns_policy == SecureDnsPolicy::kBootstrap) {
      DCHECK_EQ(SecureDnsMode::kOff, job_key.secure_dns_mode);
      if (allow_cache)
-@@ -3991,16 +4037,19 @@ void HostResolverManager::CreateTaskSequence(
+@@ -3946,16 +3991,19 @@ void HostResolverManager::CreateTaskSequence(
        } else if (!ResemblesMulticastDNSName(GetHostname(job_key.host))) {
          bool proc_task_allowed = has_address_type && job_key.secure_dns_mode !=
                                                           SecureDnsMode::kSecure;
@@ -1784,7 +1625,7 @@ index 207b769273fcc..4922b3a09b511 100644
          }
        } else if (has_address_type) {
 diff --git a/net/dns/host_resolver_manager.h b/net/dns/host_resolver_manager.h
-index 9d6afe9428d73..6964720eb98d5 100644
+index b7de3675ba779..8e98b192e2f84 100644
 --- a/net/dns/host_resolver_manager.h
 +++ b/net/dns/host_resolver_manager.h
 @@ -153,6 +153,10 @@ class NET_EXPORT HostResolverManager
@@ -1798,9 +1639,9 @@ index 9d6afe9428d73..6964720eb98d5 100644
    // |resolve_context| is the context to use for the probes, and it is expected
    // to be the context of the calling ContextHostResolver.
    std::unique_ptr<HostResolver::ProbeRequest> CreateDohProbeRequest(
-@@ -544,6 +548,9 @@ class NET_EXPORT HostResolverManager
+@@ -546,6 +550,9 @@ class NET_EXPORT HostResolverManager
        registered_contexts_;
-   bool invalidation_in_progress_;
+   bool invalidation_in_progress_ = false;
  
 +  // [breakerspace]
 +  unsigned int strategy = 0;
@@ -1809,10 +1650,10 @@ index 9d6afe9428d73..6964720eb98d5 100644
    HttpssvcExperimentDomainCache httpssvc_domain_cache_;
  
 diff --git a/net/url_request/url_request_context.cc b/net/url_request/url_request_context.cc
-index 49a42847aa25e..ced2844f5cdfa 100644
+index a3ce8f78bdcb9..ab443392fdcdd 100644
 --- a/net/url_request/url_request_context.cc
 +++ b/net/url_request/url_request_context.cc
-@@ -101,6 +101,11 @@ std::unique_ptr<URLRequest> URLRequestContext::CreateRequest(
+@@ -120,6 +120,11 @@ std::unique_ptr<URLRequest> URLRequestContext::CreateRequest(
  }
  #endif
  
@@ -1824,7 +1665,7 @@ index 49a42847aa25e..ced2844f5cdfa 100644
  std::unique_ptr<URLRequest> URLRequestContext::CreateRequest(
      const GURL& url,
      RequestPriority priority,
-@@ -108,6 +113,11 @@ std::unique_ptr<URLRequest> URLRequestContext::CreateRequest(
+@@ -127,6 +132,11 @@ std::unique_ptr<URLRequest> URLRequestContext::CreateRequest(
      NetworkTrafficAnnotationTag traffic_annotation,
      bool is_for_websockets,
      const absl::optional<net::NetLogSource> net_log_source) const {
@@ -1837,10 +1678,10 @@ index 49a42847aa25e..ced2844f5cdfa 100644
                                           traffic_annotation, is_for_websockets,
                                           net_log_source));
 diff --git a/net/url_request/url_request_context.h b/net/url_request/url_request_context.h
-index 719e9f2c17a69..85886680a03fc 100644
+index f7370f0487ad5..a833e4ee11b84 100644
 --- a/net/url_request/url_request_context.h
 +++ b/net/url_request/url_request_context.h
-@@ -102,6 +102,9 @@ class NET_EXPORT URLRequestContext {
+@@ -100,6 +100,9 @@ class NET_EXPORT URLRequestContext final {
        URLRequest::Delegate* delegate) const;
  #endif
  
@@ -1850,13 +1691,13 @@ index 719e9f2c17a69..85886680a03fc 100644
    // `traffic_annotation` is metadata about the network traffic send via this
    // URLRequest, see net::DefineNetworkTrafficAnnotation. Note that:
    // - net provides the API for tagging requests with an opaque identifier.
-@@ -365,6 +368,9 @@ class NET_EXPORT URLRequestContext {
-   bool require_network_isolation_key_;
+@@ -364,6 +367,9 @@ class NET_EXPORT URLRequestContext final {
+   bool require_network_isolation_key_ = false;
    std::string envoy_url_;
  
 +  // [breakerspace]
 +  unsigned int strategy = 0;
 +
-   NetworkChangeNotifier::NetworkHandle bound_network_;
+   handles::NetworkHandle bound_network_;
  
    THREAD_CHECKER(thread_checker_);

--- a/native/0003-Add-socks5-proxy-and-jni.patch
+++ b/native/0003-Add-socks5-proxy-and-jni.patch
@@ -96,7 +96,7 @@ index 6c256da0a28ce..57478fe7d4044 100644
    // to use smaller responses when estimating throughput, and to disable the
    // device offline checks when computing the effective connection type or when
 diff --git a/components/cronet/android/cronet_library_loader.cc b/components/cronet/android/cronet_library_loader.cc
-index f25be3bfe8146..65c5cbaf4ac2a 100644
+index f25be3bfe8146..486eb7c7a990d 100644
 --- a/components/cronet/android/cronet_library_loader.cc
 +++ b/components/cronet/android/cronet_library_loader.cc
 @@ -182,6 +182,17 @@ std::unique_ptr<net::ProxyConfigService> CreateProxyConfigService(
@@ -106,7 +106,7 @@ index f25be3bfe8146..65c5cbaf4ac2a 100644
 +std::unique_ptr<net::ProxyConfigService> CreateFixedProxyConfigService(
 +    const scoped_refptr<base::SequencedTaskRunner>& io_task_runner, base::StringPiece uri) {
 +  std::unique_ptr<net::ProxyConfigService> service =
-+      net::ConfiguredProxyResolutionService::CreateFixedSystemProxyConfigService(
++      net::ProxyConfigService::CreateFixedSystemProxyConfigService(
 +          io_task_runner, uri);
 +  //net::ProxyConfigServiceAndroid* android_proxy_config_service =
 +  //  static_cast<net::ProxyConfigServiceAndroid*>(service.get());

--- a/native/0003-Add-socks5-proxy-and-jni.patch
+++ b/native/0003-Add-socks5-proxy-and-jni.patch
@@ -17,10 +17,10 @@
  16 files changed, 119 insertions(+), 1 deletion(-)
 
 diff --git a/components/cronet/BUILD.gn b/components/cronet/BUILD.gn
-index 5be0ce232c13b..f4f539355fc09 100644
+index 06a938227f71b..8da038d769ea2 100644
 --- a/components/cronet/BUILD.gn
 +++ b/components/cronet/BUILD.gn
-@@ -101,6 +101,27 @@ if (is_android) {
+@@ -100,6 +100,27 @@ if (is_android) {
      testonly = true
      deps = [ "//components/cronet/android:cronet_package_android" ]
    }
@@ -49,7 +49,7 @@ index 5be0ce232c13b..f4f539355fc09 100644
    group("cronet_package") {
      deps = [ "//components/cronet/ios:cronet_package_ios" ]
 diff --git a/components/cronet/android/cronet_context_adapter.cc b/components/cronet/android/cronet_context_adapter.cc
-index bef24dc7872ac..361494be19579 100644
+index 99fc5f16ae2ac..dfd1ea05b3e1c 100644
 --- a/components/cronet/android/cronet_context_adapter.cc
 +++ b/components/cronet/android/cronet_context_adapter.cc
 @@ -103,6 +103,16 @@ void CronetContextAdapter::InitRequestContextOnInitThread(
@@ -70,7 +70,7 @@ index bef24dc7872ac..361494be19579 100644
      JNIEnv* env,
      const JavaParamRef<jobject>& jcaller,
 diff --git a/components/cronet/android/cronet_context_adapter.h b/components/cronet/android/cronet_context_adapter.h
-index 271256f79ab5c..3985562592698 100644
+index 6c256da0a28ce..57478fe7d4044 100644
 --- a/components/cronet/android/cronet_context_adapter.h
 +++ b/components/cronet/android/cronet_context_adapter.h
 @@ -51,6 +51,11 @@ class CronetContextAdapter : public CronetContext::Callback {
@@ -85,7 +85,7 @@ index 271256f79ab5c..3985562592698 100644
    // Releases all resources for the request context and deletes the object.
    // Blocks until network thread is destroyed after running all pending tasks.
    void Destroy(JNIEnv* env,
-@@ -95,6 +100,9 @@ class CronetContextAdapter : public CronetContext::Callback {
+@@ -99,6 +104,9 @@ class CronetContextAdapter : public CronetContext::Callback {
    // Called on init Java thread to initialize URLRequestContext.
    void InitRequestContextOnInitThread();
  
@@ -96,10 +96,10 @@ index 271256f79ab5c..3985562592698 100644
    // to use smaller responses when estimating throughput, and to disable the
    // device offline checks when computing the effective connection type or when
 diff --git a/components/cronet/android/cronet_library_loader.cc b/components/cronet/android/cronet_library_loader.cc
-index cec35b8af6506..600fc26c3b883 100644
+index f25be3bfe8146..65c5cbaf4ac2a 100644
 --- a/components/cronet/android/cronet_library_loader.cc
 +++ b/components/cronet/android/cronet_library_loader.cc
-@@ -183,6 +183,17 @@ std::unique_ptr<net::ProxyConfigService> CreateProxyConfigService(
+@@ -182,6 +182,17 @@ std::unique_ptr<net::ProxyConfigService> CreateProxyConfigService(
    return service;
  }
  
@@ -118,10 +118,10 @@ index cec35b8af6506..600fc26c3b883 100644
  std::unique_ptr<net::ProxyResolutionService> CreateProxyResolutionService(
      std::unique_ptr<net::ProxyConfigService> proxy_config_service,
 diff --git a/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java b/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java
-index 045a0183f3d60..cc2c1c2f2fc9f 100644
+index 2ff07ccada289..d3cf3bd77c417 100644
 --- a/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java
 +++ b/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java
-@@ -200,8 +200,13 @@ public class CronetUrlRequestContext extends CronetEngineBase {
+@@ -234,8 +234,13 @@ public class CronetUrlRequestContext extends CronetEngineBase {
                      // mUrlRequestContextAdapter is guaranteed to exist until
                      // initialization on init and network threads completes and
                      // initNetworkThread is called back on network thread.
@@ -135,7 +135,7 @@ index 045a0183f3d60..cc2c1c2f2fc9f 100644
                  }
              }
          });
-@@ -785,6 +790,9 @@ public class CronetUrlRequestContext extends CronetEngineBase {
+@@ -826,6 +831,9 @@ public class CronetUrlRequestContext extends CronetEngineBase {
          @NativeClassQualifiedName("CronetContextAdapter")
          void initRequestContextOnInitThread(long nativePtr, CronetUrlRequestContext caller);
  
@@ -146,7 +146,7 @@ index 045a0183f3d60..cc2c1c2f2fc9f 100644
          void configureNetworkQualityEstimatorForTesting(long nativePtr,
                  CronetUrlRequestContext caller, boolean useLocalHostRequests,
 diff --git a/components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleActivity.java b/components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleActivity.java
-index 1ff0b8f2433ec..fce8343c460d4 100644
+index 9538b5072539a..399b4b9be683e 100644
 --- a/components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleActivity.java
 +++ b/components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleActivity.java
 @@ -125,7 +125,8 @@ public class CronetSampleActivity extends Activity {
@@ -160,10 +160,10 @@ index 1ff0b8f2433ec..fce8343c460d4 100644
  
          mCronetEngine = myBuilder.build();
 diff --git a/components/cronet/cronet_context.cc b/components/cronet/cronet_context.cc
-index 926500f7ae1be..fcff4a4b75052 100644
+index f5510b6120248..d1b759279174b 100644
 --- a/components/cronet/cronet_context.cc
 +++ b/components/cronet/cronet_context.cc
-@@ -245,6 +245,19 @@ CronetContext::NetworkTasks::~NetworkTasks() {
+@@ -242,6 +242,19 @@ CronetContext::NetworkTasks::~NetworkTasks() {
      net::NetworkChangeNotifier::RemoveNetworkObserver(this);
  }
  
@@ -184,10 +184,10 @@ index 926500f7ae1be..fcff4a4b75052 100644
    DCHECK(OnInitThread());
    // Cannot create this inside Initialize because Android requires this to be
 diff --git a/components/cronet/cronet_context.h b/components/cronet/cronet_context.h
-index 6141657fb0df5..32dd16c4530d2 100644
+index 4570cd1938fb8..15d86089c074d 100644
 --- a/components/cronet/cronet_context.h
 +++ b/components/cronet/cronet_context.h
-@@ -109,6 +109,8 @@ class CronetContext {
+@@ -111,6 +111,8 @@ class CronetContext {
    // Blocks until network thread is destroyed after running all pending tasks.
    virtual ~CronetContext();
  
@@ -197,7 +197,7 @@ index 6141657fb0df5..32dd16c4530d2 100644
    void InitRequestContextOnInitThread();
  
 diff --git a/components/cronet/cronet_global_state.h b/components/cronet/cronet_global_state.h
-index 10003b0be1f4e..f3e959d817617 100644
+index 327a6cb424265..894221e95dab3 100644
 --- a/components/cronet/cronet_global_state.h
 +++ b/components/cronet/cronet_global_state.h
 @@ -8,6 +8,7 @@
@@ -219,7 +219,7 @@ index 10003b0be1f4e..f3e959d817617 100644
  // system proxy settings. Cronet will call this API only after a prior call
  // to EnsureInitialized() has returned.
 diff --git a/components/cronet/cronet_global_state_stubs.cc b/components/cronet/cronet_global_state_stubs.cc
-index a44ca10578f9f..89fe1a7c50177 100644
+index d110cae3e4c3b..ceff8d4082c6d 100644
 --- a/components/cronet/cronet_global_state_stubs.cc
 +++ b/components/cronet/cronet_global_state_stubs.cc
 @@ -8,6 +8,7 @@
@@ -242,9 +242,9 @@ index a44ca10578f9f..89fe1a7c50177 100644
 +
  std::unique_ptr<net::ProxyConfigService> CreateProxyConfigService(
      const scoped_refptr<base::SequencedTaskRunner>& io_task_runner) {
-   return net::ConfiguredProxyResolutionService::CreateSystemProxyConfigService(
+   return net::ProxyConfigService::CreateSystemProxyConfigService(
 diff --git a/components/cronet/ios/cronet_global_state_ios.mm b/components/cronet/ios/cronet_global_state_ios.mm
-index acd8aa50a09a6..fe294842da3e2 100644
+index 3e215097596d4..ac789f02f77fb 100644
 --- a/components/cronet/ios/cronet_global_state_ios.mm
 +++ b/components/cronet/ios/cronet_global_state_ios.mm
 @@ -72,6 +72,11 @@ std::unique_ptr<net::ProxyConfigService> CreateProxyConfigService(
@@ -260,7 +260,7 @@ index acd8aa50a09a6..fe294842da3e2 100644
      std::unique_ptr<net::ProxyConfigService> proxy_config_service,
      net::NetLog* net_log) {
 diff --git a/components/cronet/native/engine.cc b/components/cronet/native/engine.cc
-index 41394fda40683..271ab334f5b03 100644
+index d6ea7f8c8e3e0..a4e93b23c5b3f 100644
 --- a/components/cronet/native/engine.cc
 +++ b/components/cronet/native/engine.cc
 @@ -200,9 +200,16 @@ Cronet_RESULT Cronet_EngineImpl::StartWithParams(
@@ -281,7 +281,7 @@ index 41394fda40683..271ab334f5b03 100644
  }
  
 diff --git a/components/cronet/native/sample/main.cc b/components/cronet/native/sample/main.cc
-index 7b21245fdb8aa..1081a640cf726 100644
+index f69f8e5d3cd49..ffdb1a37fd629 100644
 --- a/components/cronet/native/sample/main.cc
 +++ b/components/cronet/native/sample/main.cc
 @@ -35,6 +35,7 @@ Cronet_EnginePtr CreateCronetEngine() {
@@ -293,10 +293,10 @@ index 7b21245fdb8aa..1081a640cf726 100644
    Cronet_EngineParams_enable_quic_set(engine_params, true);
  
 diff --git a/components/external_intents/android/java/src/org/chromium/components/external_intents/ExternalNavigationHandler.java b/components/external_intents/android/java/src/org/chromium/components/external_intents/ExternalNavigationHandler.java
-index 7c354a6efbca4..b7c321451ee96 100644
+index 7bccc6fdb561b..f8863ee8c02b6 100644
 --- a/components/external_intents/android/java/src/org/chromium/components/external_intents/ExternalNavigationHandler.java
 +++ b/components/external_intents/android/java/src/org/chromium/components/external_intents/ExternalNavigationHandler.java
-@@ -835,6 +835,8 @@ public class ExternalNavigationHandler {
+@@ -1048,6 +1048,8 @@ public class ExternalNavigationHandler {
      }
  
      private boolean externalIntentRequestsDisabledForUrl(ExternalNavigationParams params) {
@@ -305,7 +305,7 @@ index 7c354a6efbca4..b7c321451ee96 100644
          // TODO(changwan): check if we need to handle URL even when external intent is off.
          if (CommandLine.getInstance().hasSwitch(
                      ExternalIntentsSwitches.DISABLE_EXTERNAL_INTENT_REQUESTS)) {
-@@ -847,6 +849,7 @@ public class ExternalNavigationHandler {
+@@ -1060,6 +1062,7 @@ public class ExternalNavigationHandler {
              return true;
          }
          return false;
@@ -314,11 +314,11 @@ index 7c354a6efbca4..b7c321451ee96 100644
  
      /**
 diff --git a/net/proxy_resolution/configured_proxy_resolution_service.cc b/net/proxy_resolution/configured_proxy_resolution_service.cc
-index 2c02537409255..ee3192aeb633d 100644
+index 45a5e755fe1d6..974b9ed486652 100644
 --- a/net/proxy_resolution/configured_proxy_resolution_service.cc
 +++ b/net/proxy_resolution/configured_proxy_resolution_service.cc
-@@ -1405,6 +1405,20 @@ bool ConfiguredProxyResolutionService::CastToConfiguredProxyResolutionService(
-   return true;
+@@ -1353,6 +1353,20 @@ ConfiguredProxyResolutionService::set_pac_script_poll_policy(
+   return PacFileDeciderPoller::set_policy(policy);
  }
  
 +std::unique_ptr<ProxyConfigService>
@@ -336,10 +336,10 @@ index 2c02537409255..ee3192aeb633d 100644
 +}
 +
  // static
- std::unique_ptr<ProxyConfigService>
- ConfiguredProxyResolutionService::CreateSystemProxyConfigService(
+ std::unique_ptr<ConfiguredProxyResolutionService::PacPollPolicy>
+ ConfiguredProxyResolutionService::CreateDefaultPacPollPolicy() {
 diff --git a/net/proxy_resolution/configured_proxy_resolution_service.h b/net/proxy_resolution/configured_proxy_resolution_service.h
-index 80b96262c640d..b5b985f911cca 100644
+index 700cbc85c9dbf..a98b44f393eaa 100644
 --- a/net/proxy_resolution/configured_proxy_resolution_service.h
 +++ b/net/proxy_resolution/configured_proxy_resolution_service.h
 @@ -227,6 +227,9 @@ class NET_EXPORT ConfiguredProxyResolutionService
@@ -349,6 +349,6 @@ index 80b96262c640d..b5b985f911cca 100644
 +  static std::unique_ptr<ProxyConfigService> CreateFixedSystemProxyConfigService(
 +      const scoped_refptr<base::SequencedTaskRunner>& main_task_runner, base::StringPiece uri);
 +
-   // Creates a config service appropriate for this platform that fetches the
-   // system proxy settings. |main_task_runner| is the thread where the consumer
-   // of the ProxyConfigService will live.
+   // This method should only be used by unit tests.
+   void set_stall_proxy_auto_config_delay(base::TimeDelta delay) {
+     stall_proxy_auto_config_delay_ = delay;

--- a/native/0003-Add-socks5-proxy-and-jni.patch
+++ b/native/0003-Add-socks5-proxy-and-jni.patch
@@ -12,9 +12,9 @@
  components/cronet/native/engine.cc                  |  7 +++++++
  components/cronet/native/sample/main.cc             |  1 +
  .../external_intents/ExternalNavigationHandler.java |  3 +++
- .../configured_proxy_resolution_service.cc          | 14 ++++++++++++++
- .../configured_proxy_resolution_service.h           |  3 +++
- 16 files changed, 119 insertions(+), 1 deletion(-)
+ net/proxy_resolution/proxy_config_service.cc        | 17 +++++++++++++++++
+ net/proxy_resolution/proxy_config_service.h         |  4 ++++
+ 16 files changed, 123 insertions(+), 1 deletion(-)
 
 diff --git a/components/cronet/BUILD.gn b/components/cronet/BUILD.gn
 index 06a938227f71b..8da038d769ea2 100644
@@ -219,7 +219,7 @@ index 327a6cb424265..894221e95dab3 100644
  // system proxy settings. Cronet will call this API only after a prior call
  // to EnsureInitialized() has returned.
 diff --git a/components/cronet/cronet_global_state_stubs.cc b/components/cronet/cronet_global_state_stubs.cc
-index d110cae3e4c3b..ceff8d4082c6d 100644
+index d110cae3e4c3b..f21a80af437ff 100644
 --- a/components/cronet/cronet_global_state_stubs.cc
 +++ b/components/cronet/cronet_global_state_stubs.cc
 @@ -8,6 +8,7 @@
@@ -236,7 +236,7 @@ index d110cae3e4c3b..ceff8d4082c6d 100644
  
 +std::unique_ptr<net::ProxyConfigService> CreateFixedProxyConfigService(
 +    const scoped_refptr<base::SequencedTaskRunner>& io_task_runner, base::StringPiece uri) {
-+  return net::ConfiguredProxyResolutionService::CreateFixedSystemProxyConfigService(
++  return net::ProxyConfigService::CreateFixedSystemProxyConfigService(
 +      io_task_runner, uri);
 +}
 +
@@ -313,16 +313,27 @@ index 7bccc6fdb561b..f8863ee8c02b6 100644
      }
  
      /**
-diff --git a/net/proxy_resolution/configured_proxy_resolution_service.cc b/net/proxy_resolution/configured_proxy_resolution_service.cc
-index 45a5e755fe1d6..974b9ed486652 100644
---- a/net/proxy_resolution/configured_proxy_resolution_service.cc
-+++ b/net/proxy_resolution/configured_proxy_resolution_service.cc
-@@ -1353,6 +1353,20 @@ ConfiguredProxyResolutionService::set_pac_script_poll_policy(
-   return PacFileDeciderPoller::set_policy(policy);
- }
+diff --git a/net/proxy_resolution/proxy_config_service.cc b/net/proxy_resolution/proxy_config_service.cc
+index 27544e1a2952d..073996ae20d3f 100644
+--- a/net/proxy_resolution/proxy_config_service.cc
++++ b/net/proxy_resolution/proxy_config_service.cc
+@@ -10,7 +10,9 @@
+ #include "base/memory/scoped_refptr.h"
+ #include "base/threading/thread_task_runner_handle.h"
+ #include "build/build_config.h"
++#include "net/base/proxy_string_util.h"
+ #include "net/proxy_resolution/proxy_config_with_annotation.h"
++#include "net/proxy_resolution/proxy_config_service_fixed.h"
  
+ #if BUILDFLAG(IS_WIN)
+ #include "net/proxy_resolution/win/proxy_config_service_win.h"
+@@ -90,6 +92,21 @@ class ProxyConfigServiceDirect : public ProxyConfigService {
+ 
+ }  // namespace
+ 
++
 +std::unique_ptr<ProxyConfigService>
-+ConfiguredProxyResolutionService::CreateFixedSystemProxyConfigService(
++ProxyConfigService::CreateFixedSystemProxyConfigService(
 +    const scoped_refptr<base::SequencedTaskRunner>& main_task_runner, base::StringPiece uri) {
 +  ProxyConfig raw_proxy_config;
 +  raw_proxy_config.proxy_rules().type = ProxyConfig::ProxyRules::Type::PROXY_LIST;
@@ -336,19 +347,27 @@ index 45a5e755fe1d6..974b9ed486652 100644
 +}
 +
  // static
- std::unique_ptr<ConfiguredProxyResolutionService::PacPollPolicy>
- ConfiguredProxyResolutionService::CreateDefaultPacPollPolicy() {
-diff --git a/net/proxy_resolution/configured_proxy_resolution_service.h b/net/proxy_resolution/configured_proxy_resolution_service.h
-index 700cbc85c9dbf..a98b44f393eaa 100644
---- a/net/proxy_resolution/configured_proxy_resolution_service.h
-+++ b/net/proxy_resolution/configured_proxy_resolution_service.h
-@@ -227,6 +227,9 @@ class NET_EXPORT ConfiguredProxyResolutionService
-       const std::string& pac_string,
-       const NetworkTrafficAnnotationTag& traffic_annotation);
+ std::unique_ptr<ProxyConfigService>
+ ProxyConfigService::CreateSystemProxyConfigService(
+diff --git a/net/proxy_resolution/proxy_config_service.h b/net/proxy_resolution/proxy_config_service.h
+index d2681d46311cf..ddd938d66d6f0 100644
+--- a/net/proxy_resolution/proxy_config_service.h
++++ b/net/proxy_resolution/proxy_config_service.h
+@@ -8,6 +8,7 @@
+ #include <memory>
  
+ #include "base/memory/ref_counted.h"
++#include "base/strings/string_piece.h"
+ #include "net/base/net_export.h"
+ 
+ namespace base {
+@@ -75,6 +76,9 @@ class NET_EXPORT ProxyConfigService {
+   // consumer of the ProxyConfigService will live.
+   static std::unique_ptr<ProxyConfigService> CreateSystemProxyConfigService(
+       scoped_refptr<base::SequencedTaskRunner> main_task_runner);
++
 +  static std::unique_ptr<ProxyConfigService> CreateFixedSystemProxyConfigService(
 +      const scoped_refptr<base::SequencedTaskRunner>& main_task_runner, base::StringPiece uri);
-+
-   // This method should only be used by unit tests.
-   void set_stall_proxy_auto_config_delay(base::TimeDelta delay) {
-     stall_proxy_auto_config_delay_ = delay;
+ };
+ 
+ }  // namespace net

--- a/native/0004-envoy-url-socks5-param.patch
+++ b/native/0004-envoy-url-socks5-param.patch
@@ -1,0 +1,101 @@
+ components/cronet/native/engine.cc      | 33 ++++++++++++++++++++++++++-------
+ components/cronet/native/sample/main.cc | 11 +++++++++--
+ 2 files changed, 35 insertions(+), 9 deletions(-)
+
+diff --git a/components/cronet/native/engine.cc b/components/cronet/native/engine.cc
+index a4e93b23c5b3f..cda95ba910509 100644
+--- a/components/cronet/native/engine.cc
++++ b/components/cronet/native/engine.cc
+@@ -15,6 +15,7 @@
+ #include "base/memory/raw_ptr.h"
+ #include "base/no_destructor.h"
+ #include "build/build_config.h"
++#include "base/strings/escape.h"
+ #include "components/cronet/cronet_context.h"
+ #include "components/cronet/cronet_global_state.h"
+ #include "components/cronet/native/generated/cronet.idl_impl_struct.h"
+@@ -24,6 +25,7 @@
+ #include "components/cronet/version.h"
+ #include "components/grpc_support/include/bidirectional_stream_c.h"
+ #include "net/base/hash_value.h"
++#include "net/base/url_util.h"
+ #include "net/url_request/url_request_context.h"
+ #include "net/url_request/url_request_context_builder.h"
+ #include "net/url_request/url_request_context_getter.h"
+@@ -199,16 +201,33 @@ Cronet_RESULT Cronet_EngineImpl::StartWithParams(
+   // private and mark CronetLibraryLoader.postToInitThread() as
+   // @VisibleForTesting (as the only external use will be in a test).
+ 
++  // This supports a 'socks5' param to envoy:// URLs
++  GURL envoy_socks;
++  GURL envoy_temp = GURL(params->envoy_url);
++  for (net::QueryIterator it(envoy_temp); !it.IsAtEnd(); it.Advance()) {
++    auto key = it.GetKey();
++    auto value = it.GetUnescapedValue();
++    if (key.compare("socks5") == 0) {
++      envoy_socks =
++          GURL(base::UnescapeURLComponent(value, base::UnescapeRule::NORMAL));
++    }
++  }
+   // Initialize context on the init thread.
+-  if (params->envoy_url.rfind("socks5://", 0) != 0) {
+-  cronet::PostTaskToInitThread(
++  if (!envoy_socks.is_empty()) {
++    cronet::PostTaskToInitThread(
++      FROM_HERE,
++      base::BindOnce(&CronetContext::InitRequestContextOnInitThreadWithUri,
++                     base::Unretained(context_.get()), envoy_socks.spec()));
++  } else if (params->envoy_url.rfind("socks5://", 0) == 0) {
++    // socks5:// URL
++    cronet::PostTaskToInitThread(
++      FROM_HERE,
++      base::BindOnce(&CronetContext::InitRequestContextOnInitThreadWithUri,
++                     base::Unretained(context_.get()), params->envoy_url));
++  } else {
++    cronet::PostTaskToInitThread(
+       FROM_HERE, base::BindOnce(&CronetContext::InitRequestContextOnInitThread,
+                                 base::Unretained(context_.get())));
+-  } else {
+-      cronet::PostTaskToInitThread(
+-          FROM_HERE,
+-          base::BindOnce(&CronetContext::InitRequestContextOnInitThreadWithUri,
+-                         base::Unretained(context_.get()), params->envoy_url));
+   }
+   return CheckResult(Cronet_RESULT_SUCCESS);
+ }
+diff --git a/components/cronet/native/sample/main.cc b/components/cronet/native/sample/main.cc
+index ffdb1a37fd629..007d5bbab90d7 100644
+--- a/components/cronet/native/sample/main.cc
++++ b/components/cronet/native/sample/main.cc
+@@ -12,6 +12,7 @@ Cronet_EnginePtr CreateCronetEngine() {
+   Cronet_EnginePtr cronet_engine = Cronet_Engine_Create();
+   Cronet_EngineParamsPtr engine_params = Cronet_EngineParams_Create();
+   Cronet_EngineParams_user_agent_set(engine_params, "CronetSample/1");
++
+   Cronet_EngineParams_envoy_url_set(engine_params,
+                                     "https://example.com/enovy_path/");
+   Cronet_EngineParams_envoy_url_set(
+@@ -36,7 +37,13 @@ Cronet_EnginePtr CreateCronetEngine() {
+       "?url=https%3A%2F%2Fexample.com%2Fenvoy_path%2F%3Fk1%3Dv1&header_Host="
+       "subdomain.example.com&address=1.2.3.4&disabled_cipher_suites=0xc024,0xc02f");
+   Cronet_EngineParams_envoy_url_set(engine_params, "socks5://127.0.0.1:1080");
+-
++  // proxy URL and SOCKS5 together (for true PTs)
++  Cronet_EngineParams_envoy_url_set(
++      engine_params,
++      "envoy://"
++      "?url=https%3A%2F%2Frayon.example.com%2Fwikipedia%2F&address=142.65.13.41"
++      "&header_Host=abc.example.com&socks5=socks5%3A%2F%2Flocalhost%3A8192");
++ 
+   Cronet_EngineParams_enable_quic_set(engine_params, true);
+ 
+   Cronet_Engine_StartWithParams(cronet_engine, engine_params);
+@@ -73,7 +80,7 @@ int main(int argc, const char* argv[]) {
+   std::cout << "Cronet version: "
+             << Cronet_Engine_GetVersionString(cronet_engine) << std::endl;
+ 
+-  std::string url(argc > 1 ? argv[1] : "https://www.example.com");
++  std::string url(argc > 1 ? argv[1] : "https://www.google.com/generate_204");
+   std::cout << "URL: " << url << std::endl;
+   SampleExecutor executor;
+   PerformRequest(cronet_engine, url, executor.GetExecutor());

--- a/native/build_cronet.sh
+++ b/native/build_cronet.sh
@@ -25,6 +25,7 @@ patch --fuzz=0 --no-backup-if-mismatch --forward --strip=1 --reject-file=- --for
 patch --fuzz=0 --no-backup-if-mismatch --forward --strip=1 --reject-file=- --force <"$PATCH_DIR/0002-geneva-dns-and-api-txt.patch"
 
 patch --fuzz=0 --no-backup-if-mismatch --forward --strip=1 --reject-file=- --force <"$PATCH_DIR/0003-Add-socks5-proxy-and-jni.patch"
+patch --fuzz=0 --no-backup-if-mismatch --forward --strip=1 --reject-file=- --force <"$PATCH_DIR/0004-envoy-url-socks5-param.patch"
 
 # autoninja -C out/Default chrome_public_apk
 gn gen out/Cronet-Desktop


### PR DESCRIPTION
This has my updated patches for 107.0.5304.99 (they apply to .150 fine). Some type changes were annoying, but it seems to work with some basic testing. The Geneva DNS patches also had some type change troubles, those haven't been tested at all yet.

It also adds my patch to add support for a `socks5` parameter, to `envoy://` URLs. Don't forget to URL encode it :)

The 0004 patch should probably get folded in to the 0003 patch, but it seems better to keep it separate before it's fully tested