### PR TITLE
Disable demo

### DIFF
--- a/android/envoy/build.gradle
+++ b/android/envoy/build.gradle
@@ -2,12 +2,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-
-    // exclude lint task from demo project that causes release builds to fail
-    if (gradle.startParameter.taskNames.contains("assembleRelease")) {
-        gradle.startParameter.excludedTaskNames += ":demo:lintVitalRelease"
-    }
-
     compileSdkVersion 29
     buildToolsVersion '30.0.2'
     //ndkVersion '20.0.5594570'

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,2 +1,2 @@
-include ':envoy', ':cronet', ':demo'
+include ':envoy', ':cronet'
 rootProject.name = 'Envoy'


### PR DESCRIPTION
Disable the unmaintained "demo" code, we have better, more up-to-date demo projects linked in the README (Wiki Unblocked, Feeder, Tusky)

I don't know if that linter setting should be moved to the demo build.gradle, the comment doesn't say why it causes a failure, but it might be needed if anyone ever wants to revive the demo project 🤷