### PR TITLE
Upgrade buildsdk

### DIFF
--- a/android/envoy/build.gradle
+++ b/android/envoy/build.gradle
@@ -2,14 +2,13 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 33
     buildToolsVersion '30.0.2'
-    //ndkVersion '20.0.5594570'
     ndkVersion '21.0.6113669'
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 33
         versionCode 1
         versionName '1.0'
 
@@ -37,17 +36,12 @@ android {
 }
 
 dependencies {
-    // implementation fileTree(dir: 'libs', include: ['*.jar'])
-    // implementation 'androidx.appcompat:appcompat:1.1.0'
     //testImplementation 'junit:junit:4.12'
     //androidTestImplementation 'androidx.test:runner:1.1.1'
     //androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
 
     implementation('com.squareup.okhttp3:okhttp:4.6.0')
     implementation('com.squareup.okhttp3:okhttp-urlconnection:4.4.1')
-    //noinspection GradleDependency
-    //implementation('com.squareup.okhttp3:okhttp:3.14.8')
-    //implementation('com.squareup.okhttp3:okhttp-urlconnection:3.14.8')
 
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.4.32'
     implementation 'androidx.core:core-ktx:1.3.2'

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/CronetUrlRequestCallback.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/CronetUrlRequestCallback.kt
@@ -147,9 +147,6 @@ class CronetUrlRequestCallback @JvmOverloads internal constructor(
                 negotiatedProtocol.contains("1.1") -> {
                     Protocol.HTTP_1_1
                 }
-                negotiatedProtocol.contains("spdy") -> {
-                    Protocol.SPDY_3
-                }
                 else -> {
                     Protocol.HTTP_1_0
                 }


### PR DESCRIPTION
I started out removing the commented out junk and realized we should probably bump compileSdkVersion/targetSdkVersion to the latest. I also removed that check in `CronetUrlRequestCallback.kt` that was generating a warning about OkHttp having dropped support for SPDY