### PR TITLE
disabled retry limits for debug builds

### DIFF
--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/NetworkIntentService.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/NetworkIntentService.kt
@@ -335,6 +335,12 @@ class NetworkIntentService : IntentService("NetworkIntentService") {
 
     private fun shouldSubmitUrl(url: String): Boolean {
 
+        // disable this feature for debugging
+        if (BuildConfig.BUILD_TYPE == "debug") {
+            Log.d(TAG, "debug build, ignore time limit and submit")
+            return true
+        }
+
         val currentTime = System.currentTimeMillis()
         val preferences = PreferenceManager.getDefaultSharedPreferences(this)
         val failureTime = preferences.getLong(url + TIME_SUFFIX, 0)


### PR DESCRIPTION
this should make back-to-back test runs more convenient.  this seems to be determined by whether or not it is a debug build of the envoy aar, not necessarily the app that includes it.