### PR TITLE
Fix Android Demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 # Vagrant setup
 .vagrant
 
+# JetBrains IDEs
+.idea
+
+# Android Studio
+local.properties

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,11 +9,11 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
+        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.21"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32'
     }
 }
 
@@ -21,12 +21,9 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        flatDir {
-            dirs 'cronet' // use .aar in cronet folder as repo to avoid new gradle error
-        }
     }
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }

--- a/android/demo/build.gradle
+++ b/android/demo/build.gradle
@@ -1,14 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '30.0.2'
     ndkVersion '21.0.6113669'
 
     defaultConfig {
+        compileSdk 34
         applicationId 'com.example.myapplication'
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 34
         versionCode 1
         versionName '1.0'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
@@ -27,28 +26,34 @@ android {
         sourceCompatibility = 1.8
         targetCompatibility = 1.8
     }
+    namespace 'com.example.myapplication'
+    lint {
+        disable 'Instantiatable'
+    }
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging true
+        }
+    }
 
     /*
     viewBinding {
         enabled = true
     }
     */
-    lintOptions {
-        disable "Instantiatable"
-    }
 }
 
 dependencies {
-    implementation 'com.squareup.okhttp3:okhttp:4.6.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     // implementation 'com.squareup.retrofit2:retrofit:2.7.1'
     implementation 'com.android.volley:volley:1.2.1'
 
     implementation project(path: ':envoy')
     implementation 'org.greatfire.envoy:cronet:107.0.5304.150-1'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
-    implementation 'com.google.android.material:material:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
+    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
 
     // debugApi(name: 'cronet-debug', ext: 'aar')
     // releaseApi(name: 'cronet-release', ext: 'aar')

--- a/android/demo/src/main/AndroidManifest.xml
+++ b/android/demo/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <application
         android:allowBackup="false"
@@ -26,6 +27,7 @@
 
         <service
             android:name="org.greatfire.envoy.ShadowsocksService"
+            android:foregroundServiceType="dataSync"
             android:exported="false"
             android:isolatedProcess="false" /> <!-- android:permission="set exported to true when this is defined" -->
         <service

--- a/android/demo/src/main/AndroidManifest.xml
+++ b/android/demo/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.example.myapplication">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -9,7 +8,6 @@
 
     <application
         android:allowBackup="false"
-        android:extractNativeLibs="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
@@ -18,7 +16,8 @@
         tools:targetApi="m">
         <activity
             android:name=".MainActivity"
-            android:theme="@style/Theme.AppCompat.NoActionBar">
+            android:theme="@style/Theme.AppCompat.NoActionBar"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/android/envoy/build.gradle
+++ b/android/envoy/build.gradle
@@ -2,15 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
-    buildToolsVersion '30.0.2'
     ndkVersion '21.0.6113669'
 
     defaultConfig {
+        compileSdk 34
         minSdkVersion 21
-        targetSdkVersion 33
-        versionCode 1
-        versionName '1.0'
+        targetSdkVersion 34
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
@@ -24,7 +21,10 @@ android {
     }
 
     sourceSets {
-        main.java.srcDirs = ['src/main/kotlin', 'src/test/kotlin']
+        main {
+            java.srcDirs = ['src/main/kotlin',]
+            jniLibs.srcDirs = ['../cronet']
+        }
     }
     compileOptions {
         sourceCompatibility = 1.8
@@ -33,6 +33,10 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+    namespace 'org.greatfire.envoy'
+    buildFeatures {
+        buildConfig true
+    }
 }
 
 dependencies {
@@ -40,13 +44,13 @@ dependencies {
     //androidTestImplementation 'androidx.test:runner:1.1.1'
     //androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
 
-    implementation('com.squareup.okhttp3:okhttp:4.6.0')
-    implementation('com.squareup.okhttp3:okhttp-urlconnection:4.4.1')
+    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
+    implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.4.1'
 
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.4.32'
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.preference:preference-ktx:1.1.1'
-    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.0'
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.preference:preference-ktx:1.2.1'
+    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
     implementation 'org.greatfire.envoy:cronet:107.0.5304.150-1'
     implementation 'org.greatfire:IEnvoyProxy:1.5.0'
 
@@ -64,78 +68,80 @@ exec {
 version = stdout.toString().trim()
 group = 'org.greatfire'
 
-task sourcesZip {
-  def src = 'https://github.com/greatfire/envoy/archive/refs/tags/' + project.version + '.zip'
-  def destdir = project.getBuildDir().toString() + "/outputs/aar"
-  def destfile = "$destdir/envoy-" + project.version + "-sources.zip"
-  doLast {
-    def url = new URL(src)
-    def f = new File(destfile)
-    if (f.exists()) {
-      println "file $destfile already exists, skipping download"
-    } else {
-      mkdir "$destdir"
-      println "Downloading $destfile from $url..."
-      url.withInputStream { i -> f.withOutputStream { it << i } }
+tasks.register('sourcesZip') {
+    def src = 'https://github.com/greatfire/envoy/archive/refs/tags/' + project.version + '.zip'
+    def destdir = project.getBuildDir().toString() + "/outputs/aar"
+    def destfile = "$destdir/envoy-" + project.version + "-sources.zip"
+    doLast {
+        def url = new URL(src)
+        def f = new File(destfile)
+        if (f.exists()) {
+            println "file $destfile already exists, skipping download"
+        } else {
+            mkdir "$destdir"
+            println "Downloading $destfile from $url..."
+            url.withInputStream { i -> f.withOutputStream { it << i } }
+        }
     }
-  }
 }
 
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
-task writeNewPom {
-    pom {
-        project {
-            name 'Envoy'
-            packaging 'aar'
-            artifactId 'envoy'
-            inceptionYear '2018'
-            url 'https://github.com/greatfire/envoy'
-            description 'C and Java Library derived from Chromium cronet'
-            licenses {
-                license {
-                    name 'The Apache Software License, Version 2.0'
-                    url 'https://github.com/greatfire/envoy/blob/master/LICENSE'
-                    distribution 'repo'
-                }
-                license {
-                    name 'BSD-3-clause'
-                    url 'https://chromium.googlesource.com/chromium/src/+/refs/heads/main/LICENSE'
-                    distribution 'repo'
-                }
-            }
-            developers {
-                developer {
-                    id = 'greatfire'
-                    name = 'GreatFire'
-                    email = 'support@greatfire.org'
-                }
-                developer {
-                    id = 'guardianproject'
-                    name = 'Guardian Project'
-                    email = 'support@guardianproject.info'
-                }
-            }
-            issueManagement {
-                url = "https://github.com/greatfire/envoy/issues"
-                system = "GitHub"
-            }
-            scm {
-                connection = 'scm:git:https://github.com/greatfire/envoy.git'
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            pom {
+                name = 'Envoy'
+                packaging = 'aar'
+                artifactId = 'envoy'
+                inceptionYear = '2018'
                 url = 'https://github.com/greatfire/envoy'
-            }
-            dependencies {
-                dependency {
-                    groupId = 'org.greatfire.envoy'
-                    artifactId = 'cronet'
-                    version = '107.0.5304.150-1'
+                description = 'C and Java Library derived from Chromium cronet'
+                licenses {
+                    license {
+                        name = 'The Apache Software License, Version 2.0'
+                        url = 'https://github.com/greatfire/envoy/blob/master/LICENSE'
+                        distribution = 'repo'
+                    }
+                    license {
+                        name = 'BSD-3-clause'
+                        url = 'https://chromium.googlesource.com/chromium/src/+/refs/heads/main/LICENSE'
+                        distribution = 'repo'
+                    }
                 }
-                dependency {
-                    groupId = 'org.greatfire'
-                    artifactId = 'IEnvoyProxy'
-                    version = '1.5.0'
+                developers {
+                    developer {
+                        id = 'greatfire'
+                        name = 'GreatFire'
+                        email = 'support@greatfire.org'
+                    }
+                    developer {
+                        id = 'guardianproject'
+                        name = 'Guardian Project'
+                        email = 'support@guardianproject.info'
+                    }
                 }
+                issueManagement {
+                    url = "https://github.com/greatfire/envoy/issues"
+                    system = "GitHub"
+                }
+                scm {
+                    connection = 'scm:git:https://github.com/greatfire/envoy.git'
+                    url = 'https://github.com/greatfire/envoy'
+                }
+//                dependencies {
+//                    dependency {
+//                        groupId = 'org.greatfire.envoy'
+//                        artifactId = 'cronet'
+//                        version = '107.0.5304.150-1'
+//                    }
+//                    dependency {
+//                        groupId = 'org.greatfire'
+//                        artifactId = 'IEnvoyProxy'
+//                        version = '1.5.0'
+//                    }
+//                }
             }
         }
-    }.writeTo(project.getBuildDir().toString() + "/outputs/aar/" + "envoy" + "-" + project.version + ".pom")
+    }
 }

--- a/android/envoy/src/main/AndroidManifest.xml
+++ b/android/envoy/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="org.greatfire.envoy">
+<manifest>
 </manifest>

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/NetworkIntentService.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/NetworkIntentService.kt
@@ -52,11 +52,13 @@ private const val DEFAULT_USER_AGENT = ("Mozilla/5.0 (X11; Linux x86_64) "
 
 class NetworkIntentService : IntentService("NetworkIntentService") {
     // https://android.googlesource.com/platform/frameworks/base.git/+/oreo-release/services/core/java/com/android/server/connectivity/NetworkMonitor.java
+    @Deprecated("Deprecated in Java")
     override fun onCreate() {
         super.onCreate()
         Log.d(TAG, "NetworkIntentService created")
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onDestroy() {
         super.onDestroy()
         Log.d(TAG, "NetworkIntentService destroyed")
@@ -191,6 +193,7 @@ class NetworkIntentService : IntentService("NetworkIntentService") {
         fun getService(): NetworkIntentService = this@NetworkIntentService
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onHandleIntent(intent: Intent?) {
         when (intent?.action) {
             ACTION_SUBMIT -> {
@@ -207,6 +210,7 @@ class NetworkIntentService : IntentService("NetworkIntentService") {
         }
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onBind(intent: Intent): IBinder {
         return binder
     }

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/ShadowsocksService.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/ShadowsocksService.kt
@@ -6,6 +6,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.Service
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.os.Binder
 import android.os.Build
 import android.os.IBinder
@@ -67,7 +68,13 @@ class ShadowsocksService : Service() {
             .setTicker("Shadowsocks service is running")
             .build()
 
-        startForeground(SystemClock.uptimeMillis().toInt(), notification)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            startForeground(SystemClock.uptimeMillis().toInt(), notification)
+        }
+        else {
+            startForeground(SystemClock.uptimeMillis().toInt(), notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        }
 
         val nativeLibraryDir = applicationInfo.nativeLibraryDir
         val executableFile = File(nativeLibraryDir, "libsslocal.so")

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -18,3 +18,5 @@ android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
 
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=8c12154228a502b784f451179846e518733cf856efc7d45b2e6691012977b2fe
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip
+#distributionSha256Sum=cb87f222c5585bd46838ad4db78463a5c5f3d336e5e2b98dc7c0c586527351c2
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,2 +1,2 @@
-include ':envoy', ':cronet'
+include ':envoy', ':cronet', ':demo'
 rootProject.name = 'Envoy'


### PR DESCRIPTION
This patches bring all dependencies up to latest versions, including all Gradle stuff, so it actually compiles on a current Android Studio Hedgehog.

It also moves to API 34 and fixes a crash due to lacking foreground service type description.