### PR TITLE
enable h2, h3, and brotli for the direct connection test

### DIFF
--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/NetworkIntentService.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/NetworkIntentService.kt
@@ -870,12 +870,7 @@ class NetworkIntentService : IntentService("NetworkIntentService") {
         Log.d(TAG, "create direct request to " + UrlUtil.sanitizeUrl(directUrl, ENVOY_SERVICE_DIRECT))
 
         val executor: Executor = Executors.newSingleThreadExecutor()
-        val myBuilder = CronetEngine.Builder(applicationContext)
-        val cronetEngine: CronetEngine = myBuilder
-            .enableBrotli(true)
-            .enableHttp2(true)
-            .enableQuic(true)
-            .setUserAgent(DEFAULT_USER_AGENT).build()
+        val cronetEngine: CronetEngine = CronetNetworking.buildEngine(context = applicationContext)
         val requestBuilder = cronetEngine.newUrlRequestBuilder(
             directUrl,
             MyUrlRequestCallback(
@@ -908,21 +903,16 @@ class NetworkIntentService : IntentService("NetworkIntentService") {
         if (cacheMap.keys.contains(originalUrl)) {
 
             Log.d(TAG, "cache setup, found cache directory for " + sanitizedOriginal + " -> " + cacheMap.get(originalUrl))
-            val cacheDir = File(applicationContext.cacheDir, cacheMap.get(originalUrl))
 
             try {
                 val executor: Executor = Executors.newSingleThreadExecutor()
-                val myBuilder = CronetEngine.Builder(applicationContext)
-                val cronetEngine: CronetEngine = myBuilder
-                    .enableBrotli(true)
-                    .enableHttp2(true)
-                    .enableQuic(true)
-                    .setEnvoyUrl(envoyUrl)
-                    .SetStrategy(strategy)
-                    .setStoragePath(cacheDir.absolutePath)
-                    .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_DISK, 1 * 1024 * 1024) // 1 megabyte
-                    .setUserAgent(DEFAULT_USER_AGENT)
-                    .build()
+                val cronetEngine: CronetEngine = CronetNetworking.buildEngine(
+                    context = applicationContext,
+                    cacheFolder = cacheMap.get(originalUrl),
+                    envoyUrl = envoyUrl,
+                    strategy = strategy,
+                    cacheSize = 1
+                )
                 val requestBuilder = cronetEngine.newUrlRequestBuilder(
                     captive_portal_url,
                     MyUrlRequestCallback(
@@ -938,7 +928,7 @@ class NetworkIntentService : IntentService("NetworkIntentService") {
                 Log.d(TAG, "cache setup, cache cronet engine for url " + sanitizedOriginal)
                 cronetMap.put(originalUrl, cronetEngine)
             } catch (ise: IllegalStateException) {
-                Log.e(TAG, "cache setup, " + cacheDir.absolutePath + " could not be used")
+                Log.e(TAG, "cache setup, cache directory " + cacheMap.get(originalUrl) + " could not be used")
             }
         } else {
             Log.e(TAG, "cache setup, could not find cache directory for " + sanitizedOriginal)

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/NetworkIntentService.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/NetworkIntentService.kt
@@ -872,6 +872,9 @@ class NetworkIntentService : IntentService("NetworkIntentService") {
         val executor: Executor = Executors.newSingleThreadExecutor()
         val myBuilder = CronetEngine.Builder(applicationContext)
         val cronetEngine: CronetEngine = myBuilder
+            .enableBrotli(true)
+            .enableHttp2(true)
+            .enableQuic(true)
             .setUserAgent(DEFAULT_USER_AGENT).build()
         val requestBuilder = cronetEngine.newUrlRequestBuilder(
             directUrl,


### PR DESCRIPTION
This isn't really my bailiwick, but it seems like we should be enabling http2 and quic in the direct connection test (and brotli too), like we do in other places. The later code that tests the proxies enables the cache and this doesn't. Maybe it makes sense to refactor this code so there's only one interface to the cronet engine builder so we can make sure we're calling it consistently across the different places we use it?

Also this call to the builder doesn't enable the cache, but the later captive portal testing code does enable the cache. I don't remember the details about the caching, but it seems simpler to disable the cache when testing the captive portal URL later in the code. I'm not sure why you'd want the cache on, or did it need that enabled to work? We'd never want a cached response from that, I don't think

FWIW I didn't actually test this change, it's just copy and paste code, but it looks right :)