### PR TITLE
Moved package definitions to root directory

### DIFF
--- a/Envoy.podspec
+++ b/Envoy.podspec
@@ -39,11 +39,11 @@ Pod::Spec.new do |s|
 
   s.static_framework = true
 
-  s.source_files = 'Sources/Envoy/**/*'
+  s.source_files = 'apple/Sources/Envoy/**/*'
 
   s.dependency 'IEnvoyProxy', '~> 2.0'
 
   s.test_spec 'Tests' do |t|
-      t.source_files = 'Tests/EnvoyTests/**/*'
+      t.source_files = 'apple/Tests/EnvoyTests/**/*'
   end
 end

--- a/Package.swift
+++ b/Package.swift
@@ -18,11 +18,15 @@ let package = Package(
         .target(
             name: "Envoy",
             dependencies: ["IEnvoyProxy"],
+            path: "apple",
+            exclude: ["Example"],
             // Needed for IEnvoyProxy, but not allowed in `.binaryTarget`. Hrgrml. But works this way.
             linkerSettings: [.linkedLibrary("resolv")]),
         .testTarget(
             name: "EnvoyTests",
-            dependencies: ["Envoy"]),
+            dependencies: ["Envoy"],
+            path: "apple",
+            exclude: ["Example"]),
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/apple/Example/Envoy.xcodeproj/project.pbxproj
+++ b/apple/Example/Envoy.xcodeproj/project.pbxproj
@@ -48,7 +48,7 @@
 		A041A2072C4A8EB8008353F8 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Package.swift; path = ../Package.swift; sourceTree = "<group>"; };
 		A04B51922C414E940050CA0A /* proxies.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = proxies.plist; sourceTree = "<group>"; };
 		A04B51962C41500F0050CA0A /* Proxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Proxy.swift; sourceTree = "<group>"; };
-		B6E06D5D3A03A92B82B4D2FC /* Envoy.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Envoy.podspec; path = ../Envoy.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		A0730A492C500E58009A1C51 /* Envoy.podspec */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = text; name = Envoy.podspec; path = ../../Envoy.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		D8C5EC9BC94045C321655445 /* Pods-Example for MacOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example for MacOS.release.xcconfig"; path = "Target Support Files/Pods-Example for MacOS/Pods-Example for MacOS.release.xcconfig"; sourceTree = "<group>"; };
 		DD7379308FB4B10EECA1F2D1 /* Pods_Example_for_MacOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example_for_MacOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E613D66F9A0E5D47D6542ACD /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
@@ -127,7 +127,7 @@
 		607FACF51AFB993E008FA782 /* Podspec Metadata */ = {
 			isa = PBXGroup;
 			children = (
-				B6E06D5D3A03A92B82B4D2FC /* Envoy.podspec */,
+				A0730A492C500E58009A1C51 /* Envoy.podspec */,
 				A041A2072C4A8EB8008353F8 /* Package.swift */,
 				E613D66F9A0E5D47D6542ACD /* README.md */,
 				A018BCC92BAC761700EC6172 /* Podfile */,

--- a/apple/Example/Envoy.xcodeproj/project.pbxproj
+++ b/apple/Example/Envoy.xcodeproj/project.pbxproj
@@ -45,10 +45,10 @@
 		A0258D052C3ECB3A00B3A9E7 /* Envoy_Example-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Envoy_Example-Bridging-Header.h"; sourceTree = "<group>"; };
 		A0258D062C3ECB3A00B3A9E7 /* ObjcViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjcViewController.h; sourceTree = "<group>"; };
 		A0258D072C3ECB3A00B3A9E7 /* ObjcViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcViewController.m; sourceTree = "<group>"; };
-		A041A2072C4A8EB8008353F8 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Package.swift; path = ../Package.swift; sourceTree = "<group>"; };
 		A04B51922C414E940050CA0A /* proxies.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = proxies.plist; sourceTree = "<group>"; };
 		A04B51962C41500F0050CA0A /* Proxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Proxy.swift; sourceTree = "<group>"; };
 		A0730A492C500E58009A1C51 /* Envoy.podspec */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = text; name = Envoy.podspec; path = ../../Envoy.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		A0730A4A2C501074009A1C51 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Package.swift; path = ../../Package.swift; sourceTree = "<group>"; };
 		D8C5EC9BC94045C321655445 /* Pods-Example for MacOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example for MacOS.release.xcconfig"; path = "Target Support Files/Pods-Example for MacOS/Pods-Example for MacOS.release.xcconfig"; sourceTree = "<group>"; };
 		DD7379308FB4B10EECA1F2D1 /* Pods_Example_for_MacOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example_for_MacOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E613D66F9A0E5D47D6542ACD /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
@@ -128,7 +128,7 @@
 			isa = PBXGroup;
 			children = (
 				A0730A492C500E58009A1C51 /* Envoy.podspec */,
-				A041A2072C4A8EB8008353F8 /* Package.swift */,
+				A0730A4A2C501074009A1C51 /* Package.swift */,
 				E613D66F9A0E5D47D6542ACD /* README.md */,
 				A018BCC92BAC761700EC6172 /* Podfile */,
 				A018BCCA2BAC761700EC6172 /* Podfile.lock */,

--- a/apple/Example/Podfile
+++ b/apple/Example/Podfile
@@ -5,7 +5,7 @@ use_frameworks!
 target 'Envoy_Example' do
   platform :ios, '14.0'
 
-  pod 'Envoy', :path => '../', :testspecs => ['Tests']
+  pod 'Envoy', :path => '../../', :testspecs => ['Tests']
 #  pod 'IEnvoyProxy',
 #    :path => '../../../IEnvoyProxy'
 #    :git => 'https://github.com/tladesignz/IEnvoyProxy.git'
@@ -15,5 +15,5 @@ end
 target 'Example for MacOS' do
   platform :osx, '11'
 
-  pod 'Envoy', :path => '../', :testspecs => ['Tests']
+  pod 'Envoy', :path => '../../', :testspecs => ['Tests']
 end

--- a/apple/Example/Podfile.lock
+++ b/apple/Example/Podfile.lock
@@ -6,8 +6,8 @@ PODS:
   - IEnvoyProxy (2.0.1)
 
 DEPENDENCIES:
-  - Envoy (from `../`)
-  - Envoy/Tests (from `../`)
+  - Envoy (from `../../`)
+  - Envoy/Tests (from `../../`)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -15,12 +15,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Envoy:
-    :path: "../"
+    :path: "../../"
 
 SPEC CHECKSUMS:
-  Envoy: e2014c03132335095f458bafef33ad07c6866fd7
+  Envoy: 091698751e7b285893f25e1ab7f6c676bf3b270f
   IEnvoyProxy: 51bc3a4909edcc0eea86841072a1ea2fd49e7b5c
 
-PODFILE CHECKSUM: 4eeb14cca2618ee66e077adc2f54964503df3dcf
+PODFILE CHECKSUM: 819a3176634ff7902c1618a68ae5a4f991ea261f
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
The podspec and the Package.swift files need to go in the root directory. Sorry.

Please move the `apple-0.1.0` tag forward to the last commit after merging.

Thank you!