### PR TITLE
Fixed CocoaPods package config

### DIFF
--- a/GreatfireEnvoy.podspec
+++ b/GreatfireEnvoy.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
   s.swift_versions = '5.0'
 
   s.ios.deployment_target = '13.0'
-  s.osx.deployment_target = '11'
+  s.osx.deployment_target = '12'
 
   s.static_framework = true
 

--- a/apple/Example/Podfile.lock
+++ b/apple/Example/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
     - GreatfireEnvoy/Core
     - SwiftyCurl (~> 0.4)
   - IEnvoyProxy (3.0.0)
-  - SwiftyCurl (0.4.0)
+  - SwiftyCurl (0.4.1)
 
 DEPENDENCIES:
   - GreatfireEnvoy/Curl (from `../../`)
@@ -26,7 +26,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   GreatfireEnvoy: 5581f0c241b24298ac7610ca09fb8bd8d23a36e3
   IEnvoyProxy: 7264306407958184669e9d90844e1f3014aef44d
-  SwiftyCurl: 7c38c8d48ae276823f374e6fd13880b6538cc148
+  SwiftyCurl: 2fcde581b4fd161451e29076b2cca8624e3e347e
 
 PODFILE CHECKSUM: 7ab5a75273a64740d8d60515289326188d1226f6
 

--- a/apple/Tests/GreatfireEnvoyTests/EnvoyTests.swift
+++ b/apple/Tests/GreatfireEnvoyTests/EnvoyTests.swift
@@ -23,7 +23,7 @@ class EnvoyTests: XCTestCase {
                     salt: "abcdefghijklmnop")
 
         assertV2Ray(
-            "v2ws://127.0.0.1:12345?id=00000000-0000-0000-0000-00000000000&path=/websocket/", 
+            "v2ws://127.0.0.1:12345?id=00000000-0000-0000-0000-00000000000&path=/websocket/",
             type: .ws,
             host: "127.0.0.1",
             port: 12345,
@@ -74,7 +74,7 @@ class EnvoyTests: XCTestCase {
                         tunnel: .socks5(host: "127.0.0.1", port: 12345))
 
         assertWebTunnel("webtunnel://?url=https://example.com/abcdefghijklm&ver=0.0.1&tunnel=https://proxy.example.com/proxy/",
-                        proxyUrl: "https://example.com/abcdefghijklm", 
+                        proxyUrl: "https://example.com/abcdefghijklm",
                         ver: "0.0.1",
                         tunnel: .envoy(url: URL(string: "https://proxy.example.com/proxy/")!))
 
@@ -135,7 +135,7 @@ class EnvoyTests: XCTestCase {
         XCTAssertEqual(dict?[kCFProxyTypeKey] as! CFString, kCFProxyTypeSOCKS)
         XCTAssertEqual(dict?[kCFStreamPropertySOCKSVersion] as! CFString, kCFStreamSocketSOCKSVersion5)
         XCTAssertEqual(dict?[kCFStreamPropertySOCKSProxyHost] as! String, "127.0.0.1")
-        XCTAssertEqual(dict?[kCFStreamPropertySOCKSProxyPort] as! Int, 47300)
+        XCTAssertEqual(dict?[kCFStreamPropertySOCKSProxyPort] as! Int, 0)
 
         // Dictionaries don't have order, so the order of the arguments changes randomly on reruns.
         let arguments = (dict?[kCFStreamPropertySOCKSUser] as! String) + (dict?[kCFStreamPropertySOCKSPassword] as! String)
@@ -169,13 +169,12 @@ class EnvoyTests: XCTestCase {
             var conf = proxy.getProxyConfig()
 
             XCTAssertNotNil(conf)
-            XCTAssertEqual(conf?.debugDescription, "socksv5 Proxy: 127.0.0.1:47300")
-            
-            
+            XCTAssertEqual(conf?.debugDescription, "socksv5 Proxy: 127.0.0.1:0")
+
             proxy = .meek(url: URL(string: "https://cdn.example.com/")!, front: ".wellknown.org", tunnel: .socks5(host: "127.0.0.1", port: 12345))
-            
+
             conf = proxy.getProxyConfig()
-            
+
             XCTAssertNotNil(conf)
             XCTAssertEqual(conf?.debugDescription, "socksv5 Proxy: 127.0.0.1:\(EnvoySocksForwarder.port)")
         }
@@ -270,7 +269,7 @@ class EnvoyTests: XCTestCase {
         }
     }
 
-    private func assertSnowflake(_ url: String, ice: String? = nil, broker: String, 
+    private func assertSnowflake(_ url: String, ice: String? = nil, broker: String,
                                  fronts: String, ampCache: String? = nil, sqsQueue: String? = nil,
                                  sqsCreds: String? = nil, tunnel: Envoy.Proxy)
     {


### PR DESCRIPTION
The dependency `SwiftyCurl` enforces a higher deployment target for macOS.
Also, some tests where broken.

Without these fixes, I cannot release this to the CocoaPods package registry.

@stevenmcdonald, please merge and push the tag `apple-0.3.0` forward to that commit!

Thank you!