### PR TITLE
New Transport namespace

### DIFF
--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyConnectWorker.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyConnectWorker.kt
@@ -1,5 +1,7 @@
 package org.greatfire.envoy
 
+import org.greatfire.envoy.transport.*
+
 import android.content.Context
 import android.util.Log
 import androidx.work.CoroutineWorker
@@ -151,9 +153,8 @@ class EnvoyConnectWorker(
     // Main entry point
     override suspend fun doWork(): Result {
         // test direct connection first
-        val directTest = EnvoyConnectionTests.directTest
-        if (directTest != null) {
-            transports.add(directTest)
+        EnvoyConnectionTests.directTest?.let {
+            transports.add(it)
         }
 
         // We preserve the original list of tests in EnvoyNetworking

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyConnectionTests.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyConnectionTests.kt
@@ -1,5 +1,7 @@
 package org.greatfire.envoy
 
+import org.greatfire.envoy.transport.*
+
 import android.net.Uri
 import android.util.Log
 import java.net.InetSocketAddress

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyInterceptor.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyInterceptor.kt
@@ -28,7 +28,7 @@ class EnvoyInterceptor : Interceptor {
         val req = chain.request()
 
         if (state.connected.get()) {
-            if (state.activeServiceType.get() == EnvoyServiceType.DIRECT.ordinal) {
+            if (state.activeServiceType.get() == EnvoyTransportType.DIRECT.ordinal) {
                 Log.d(TAG, "Direct: " + req.url)
                 // pass the request through
                 return chain.proceed(chain.request())
@@ -37,33 +37,33 @@ class EnvoyInterceptor : Interceptor {
                     // proxy via Envoy
                     Log.d(TAG, "Proxy Via Envoy: " + it.testType)
                     val res = when (it.testType) {
-                        EnvoyServiceType.CRONET_ENVOY -> {
+                        EnvoyTransportType.CRONET_ENVOY -> {
                             Log.d(TAG, "Cronet request to Envoy server")
                             cronetToEnvoy(chain)
                         }
-                        EnvoyServiceType.OKHTTP_ENVOY,
+                        EnvoyTransportType.OKHTTP_ENVOY,
                         // this could also use cronet?
                         // Instead of using the Envoy proxy driectly,
                         // we use Go code as an Envoy proxy here
-                        EnvoyServiceType.HTTP_ECH -> {
+                        EnvoyTransportType.HTTP_ECH -> {
                             Log.d(TAG, "OkHttp request to Envoy server")
                             okHttpToEnvoy(chain)
                         }
-                        EnvoyServiceType.OKHTTP_PROXY,
+                        EnvoyTransportType.OKHTTP_PROXY,
                         // all of these services provive a standard SOCKS5
                         // interface. We used to pass these through Cronet,
                         // should we test both? Just use OkHttp for now
-                        EnvoyServiceType.OKHTTP_MASQUE,
-                        EnvoyServiceType.HYSTERIA2,
-                        EnvoyServiceType.V2WS,
-                        EnvoyServiceType.V2SRTP,
-                        EnvoyServiceType.V2WECHAT,
-                        EnvoyServiceType.SHADOWSOCKS, -> {
+                        EnvoyTransportType.OKHTTP_MASQUE,
+                        EnvoyTransportType.HYSTERIA2,
+                        EnvoyTransportType.V2WS,
+                        EnvoyTransportType.V2SRTP,
+                        EnvoyTransportType.V2WECHAT,
+                        EnvoyTransportType.SHADOWSOCKS, -> {
                             Log.d(TAG, "Passing request to standard proxy")
                             useStandardProxy(chain)
                         }
-                        EnvoyServiceType.CRONET_PROXY,
-                        EnvoyServiceType.CRONET_MASQUE, -> {
+                        EnvoyTransportType.CRONET_PROXY,
+                        EnvoyTransportType.CRONET_MASQUE, -> {
                             Log.d(TAG, "Passing request to cronet w/proxy")
                             useCronet(chain.request(), chain)
                         }

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyInterceptor.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyInterceptor.kt
@@ -1,5 +1,8 @@
 package org.greatfire.envoy
 
+import org.greatfire.envoy.transport.DirectTransport
+import org.greatfire.envoy.transport.Transport
+
 import android.net.Uri
 import android.util.Log
 import okhttp3.*

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyNetworking.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyNetworking.kt
@@ -1,5 +1,7 @@
 package org.greatfire.envoy
 
+import org.greatfire.envoy.transport.Transport
+
 import android.content.Context
 import android.util.Log
 import androidx.work.*

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyState.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyState.kt
@@ -1,5 +1,7 @@
 package org.greatfire.envoy
 
+import org.greatfire.envoy.transport.Transport
+
 import android.content.Context
 import android.util.Log
 import IEnvoyProxy.IEnvoyProxy // Go library

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyState.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyState.kt
@@ -33,7 +33,7 @@ class EnvoyState private constructor() {
 
     // moving this back to state because it's state
     var connected = AtomicBoolean(false)
-    var activeServiceType = AtomicInteger(EnvoyServiceType.UNKNOWN.ordinal)
+    var activeServiceType = AtomicInteger(EnvoyTransportType.UNKNOWN.ordinal)
     var activeService: Transport? = null
     val additionalWorkingConnections = mutableListOf<Transport>()
 
@@ -110,9 +110,9 @@ class EnvoyState private constructor() {
 
             // start the cronet engine if we're using a cronet service
             when (transport.testType) {
-                EnvoyServiceType.CRONET_ENVOY,
-                EnvoyServiceType.CRONET_PROXY,
-                EnvoyServiceType.CRONET_MASQUE, -> {
+                EnvoyTransportType.CRONET_ENVOY,
+                EnvoyTransportType.CRONET_PROXY,
+                EnvoyTransportType.CRONET_MASQUE, -> {
                     createCronetEngine(transport)
                 }
                 else -> "" // nothing to do
@@ -124,7 +124,7 @@ class EnvoyState private constructor() {
 
             Log.d(TAG, "🍍 activeService is $activeService")
 
-        } else if(transport.testType == EnvoyServiceType.DIRECT) {
+        } else if(transport.testType == EnvoyTransportType.DIRECT) {
             Log.i(TAG, "👉 DIRECT overriding previous connection")
 
             val previousService = activeService

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyTestUtil.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyTestUtil.kt
@@ -1,5 +1,7 @@
 package org.greatfire.envoy
 
+import org.greatfire.envoy.transport.Transport
+
 import android.util.Log
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyTestUtil.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyTestUtil.kt
@@ -104,7 +104,7 @@ class EnvoyTestUtil() {
     fun stopTestPassed(transport: Transport): Transport {
         transport.stopTimer()
 
-        if (transport.testType != EnvoyServiceType.DIRECT) {
+        if (transport.testType != EnvoyTransportType.DIRECT) {
             // passed, remove retry interval
             // this may not be thread safe, but it shouldn't be called concurrently for the same url
             preferences.clearUrlFailure(transport.url)
@@ -122,7 +122,7 @@ class EnvoyTestUtil() {
         val count = failedCount.incrementAndGet()
         Log.d(TAG, "FAILED COUNT UPDATED: " + count)
 
-        if (transport.testType != EnvoyServiceType.DIRECT) {
+        if (transport.testType != EnvoyTransportType.DIRECT) {
             // failed, update retry interval
             // this may not be thread safe, but it shouldn't be called concurrently for the same url
             val currentTime = System.currentTimeMillis()

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyTransportType.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyTransportType.kt
@@ -1,6 +1,6 @@
 package org.greatfire.envoy
 
-enum class EnvoyServiceType {
+enum class EnvoyTransportType {
     DIRECT,         // direct connection, no proxy
     OKHTTP_ENVOY,   // Use OkHttp via an Envoy proxy
     CRONET_ENVOY,   // Use Cronet via an Envoy proxy

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/CronetEnvoyTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/CronetEnvoyTransport.kt
@@ -1,14 +1,14 @@
 package org.greatfire.envoy.transport
 
 import org.greatfire.envoy.CronetNetworking
-import org.greatfire.envoy.EnvoyServiceType
+import org.greatfire.envoy.EnvoyTransportType
 
 import android.content.Context
 import android.net.Uri
 import android.util.Log
 import java.util.concurrent.Executors
 
-class CronetEnvoyTransport(url: String) : Transport(EnvoyServiceType.CRONET_ENVOY, url) {
+class CronetEnvoyTransport(url: String) : Transport(EnvoyTransportType.CRONET_ENVOY, url) {
 
     override suspend fun startTest(context: Context): Boolean {
         // proxyUrl is assumed to be an Envoy proxy because this is a Cronet Envoy test

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/CronetEnvoyTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/CronetEnvoyTransport.kt
@@ -1,4 +1,7 @@
-package org.greatfire.envoy
+package org.greatfire.envoy.transport
+
+import org.greatfire.envoy.CronetNetworking
+import org.greatfire.envoy.EnvoyServiceType
 
 import android.content.Context
 import android.net.Uri

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/CronetMasqueTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/CronetMasqueTransport.kt
@@ -1,11 +1,11 @@
 package org.greatfire.envoy.transport
 
-import org.greatfire.envoy.EnvoyServiceType
+import org.greatfire.envoy.EnvoyTransportType
 
 import IEnvoyProxy.IEnvoyProxy
 import android.content.Context
 
-class CronetMasqueTransport(url: String) : Transport(EnvoyServiceType.CRONET_MASQUE, url) {
+class CronetMasqueTransport(url: String) : Transport(EnvoyTransportType.CRONET_MASQUE, url) {
 
     override suspend fun startTest(context: Context): Boolean {
         // Not implemented, does cronet support MASQUE (yet?)

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/CronetMasqueTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/CronetMasqueTransport.kt
@@ -1,5 +1,6 @@
-package org.greatfire.envoy
+package org.greatfire.envoy.transport
 
+import org.greatfire.envoy.EnvoyServiceType
 
 import IEnvoyProxy.IEnvoyProxy
 import android.content.Context

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/CronetProxyTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/CronetProxyTransport.kt
@@ -1,4 +1,6 @@
-package org.greatfire.envoy
+package org.greatfire.envoy.transport
+
+import org.greatfire.envoy.EnvoyServiceType
 
 import android.content.Context
 

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/CronetProxyTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/CronetProxyTransport.kt
@@ -1,10 +1,10 @@
 package org.greatfire.envoy.transport
 
-import org.greatfire.envoy.EnvoyServiceType
+import org.greatfire.envoy.EnvoyTransportType
 
 import android.content.Context
 
-class CronetProxyTransport(url: String) : Transport(EnvoyServiceType.CRONET_PROXY, url) {
+class CronetProxyTransport(url: String) : Transport(EnvoyTransportType.CRONET_PROXY, url) {
     // TODO - support for this is partly implmeneted
 
     override suspend fun startService(): String {

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/DirectTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/DirectTransport.kt
@@ -1,4 +1,6 @@
-package org.greatfire.envoy
+package org.greatfire.envoy.transport
+
+import org.greatfire.envoy.EnvoyServiceType
 
 import android.content.Context
 import android.util.Log

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/DirectTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/DirectTransport.kt
@@ -1,12 +1,12 @@
 package org.greatfire.envoy.transport
 
-import org.greatfire.envoy.EnvoyServiceType
+import org.greatfire.envoy.EnvoyTransportType
 
 import android.content.Context
 import android.util.Log
 import okhttp3.Request
 
-class DirectTransport(url: String) : Transport(EnvoyServiceType.DIRECT, url) {
+class DirectTransport(url: String) : Transport(EnvoyTransportType.DIRECT, url) {
 
     override suspend fun startTest(context: Context): Boolean {
         Log.d(TAG, "Testing direct connection")

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/HttpEchTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/HttpEchTransport.kt
@@ -1,6 +1,6 @@
 package org.greatfire.envoy.transport
 
-import org.greatfire.envoy.EnvoyServiceType
+import org.greatfire.envoy.EnvoyTransportType
 
 import android.content.Context
 import android.net.Uri
@@ -8,7 +8,7 @@ import android.util.Log
 import IEnvoyProxy.IEnvoyProxy // Go library, we use constants from it here
 
 
-class HttpEchTransport(url: String) : Transport(EnvoyServiceType.HTTP_ECH, url) {
+class HttpEchTransport(url: String) : Transport(EnvoyTransportType.HTTP_ECH, url) {
 
     // was getEnvoyUrl but returns only ech url? (if available)
     fun getEchUrl(): String {

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/HttpEchTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/HttpEchTransport.kt
@@ -1,4 +1,6 @@
-package org.greatfire.envoy
+package org.greatfire.envoy.transport
+
+import org.greatfire.envoy.EnvoyServiceType
 
 import android.content.Context
 import android.net.Uri

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/Hysteria2Transport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/Hysteria2Transport.kt
@@ -1,7 +1,7 @@
 package org.greatfire.envoy.transport
 
 import org.greatfire.envoy.EnvoyConnectionTests
-import org.greatfire.envoy.EnvoyServiceType
+import org.greatfire.envoy.EnvoyTransportType
 
 import android.util.Log
 
@@ -9,7 +9,7 @@ import IEnvoyProxy.IEnvoyProxy
 import android.content.Context
 import android.net.Uri
 
-class Hysteria2Transport(url: String) : Transport(EnvoyServiceType.HYSTERIA2, url) {
+class Hysteria2Transport(url: String) : Transport(EnvoyTransportType.HYSTERIA2, url) {
 
     override suspend fun startTest(context: Context): Boolean {
         val addr = startService()

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/Hysteria2Transport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/Hysteria2Transport.kt
@@ -1,4 +1,7 @@
-package org.greatfire.envoy
+package org.greatfire.envoy.transport
+
+import org.greatfire.envoy.EnvoyConnectionTests
+import org.greatfire.envoy.EnvoyServiceType
 
 import android.util.Log
 

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/OkHttpEnvoyTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/OkHttpEnvoyTransport.kt
@@ -1,13 +1,13 @@
 package org.greatfire.envoy.transport
 
-import org.greatfire.envoy.EnvoyServiceType
+import org.greatfire.envoy.EnvoyTransportType
 
 import android.content.Context
 import android.net.Uri
 import android.util.Log
 import okhttp3.Request
 
-class OkHttpEnvoyTransport(url: String) : Transport(EnvoyServiceType.OKHTTP_ENVOY, url) {
+class OkHttpEnvoyTransport(url: String) : Transport(EnvoyTransportType.OKHTTP_ENVOY, url) {
 
     override suspend fun startTest(context: Context): Boolean {
         val host = Uri.parse(testUrl).host

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/OkHttpMasqueTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/OkHttpMasqueTransport.kt
@@ -1,4 +1,6 @@
-package org.greatfire.envoy
+package org.greatfire.envoy.transport
+
+import org.greatfire.envoy.EnvoyServiceType
 
 import android.net.Uri
 import android.util.Log

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/OkHttpMasqueTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/OkHttpMasqueTransport.kt
@@ -1,6 +1,6 @@
 package org.greatfire.envoy.transport
 
-import org.greatfire.envoy.EnvoyServiceType
+import org.greatfire.envoy.EnvoyTransportType
 
 import android.net.Uri
 import android.util.Log
@@ -8,7 +8,7 @@ import android.util.Log
 import IEnvoyProxy.IEnvoyProxy
 import android.content.Context
 
-class OkHttpMasqueTransport(url: String) : Transport(EnvoyServiceType.OKHTTP_MASQUE, url) {
+class OkHttpMasqueTransport(url: String) : Transport(EnvoyTransportType.OKHTTP_MASQUE, url) {
 
     override suspend fun startTest(context: Context): Boolean {
         if (proxyUrl == null) {

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/OkHttpProxyTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/OkHttpProxyTransport.kt
@@ -1,11 +1,13 @@
-package org.greatfire.envoy
+package org.greatfire.envoy.transport
+
+import org.greatfire.envoy.EnvoyServiceType
 
 import android.content.Context
 import android.net.Uri
 import android.util.Log
 import okhttp3.Request
 
-class OkHttpEnvoyTransport(url: String) : Transport(EnvoyServiceType.OKHTTP_ENVOY, url) {
+class OkHttpProxyTransport(url: String) : Transport(EnvoyServiceType.OKHTTP_PROXY, url) {
 
     override suspend fun startTest(context: Context): Boolean {
         val host = Uri.parse(testUrl).host
@@ -15,26 +17,17 @@ class OkHttpEnvoyTransport(url: String) : Transport(EnvoyServiceType.OKHTTP_ENVO
         }
 
         // XXX cache param, this is hacky :)
-        // this should be updated to use the same checksum param
+        // this nshould be updated to use the same checksum param
         // that the C++ patches used to use
         val t = System.currentTimeMillis()
-        val tempUrl = url + "?test=" + t
+        val url = proxyUrl.toString() + "?test=" + t
         val request = Request.Builder()
-            .url(tempUrl)
+            .url(url)
             // .head()  // a HEAD request is enough to test it works
             .addHeader("Url-Orig", testUrl)
             .addHeader("Host-Orig", host)
             .build()
 
-        val temp = runTest(request, null)
-        if (temp == true && this.proxyUrl.isNullOrEmpty()) {
-            // the Envoy proxy URL needs to be copied to proxyUrl
-            this.proxyUrl = url
-        }
-        return temp
-    }
-
-    override fun stopService() {
-        // no service to stop
+        return runTest(request, null)
     }
 }

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/OkHttpProxyTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/OkHttpProxyTransport.kt
@@ -1,13 +1,13 @@
 package org.greatfire.envoy.transport
 
-import org.greatfire.envoy.EnvoyServiceType
+import org.greatfire.envoy.EnvoyTransportType
 
 import android.content.Context
 import android.net.Uri
 import android.util.Log
 import okhttp3.Request
 
-class OkHttpProxyTransport(url: String) : Transport(EnvoyServiceType.OKHTTP_PROXY, url) {
+class OkHttpProxyTransport(url: String) : Transport(EnvoyTransportType.OKHTTP_PROXY, url) {
 
     override suspend fun startTest(context: Context): Boolean {
         val host = Uri.parse(testUrl).host

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/ShadowsocksTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/ShadowsocksTransport.kt
@@ -1,7 +1,7 @@
 package org.greatfire.envoy.transport
 
 import org.greatfire.envoy.EnvoyConnectionTests
-import org.greatfire.envoy.EnvoyServiceType
+import org.greatfire.envoy.EnvoyTransportType
 import org.greatfire.envoy.ShadowsocksService
 
 import android.content.Intent
@@ -11,7 +11,7 @@ import androidx.core.content.ContextCompat
 import android.content.Context
 import android.net.Uri
 
-class ShadowsocksTransport(url: String) : Transport(EnvoyServiceType.SHADOWSOCKS, url) {
+class ShadowsocksTransport(url: String) : Transport(EnvoyTransportType.SHADOWSOCKS, url) {
 
     override suspend fun startTest(context: Context): Boolean {
         Log.d(TAG, "Testing Shadowsocks " + this)

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/ShadowsocksTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/ShadowsocksTransport.kt
@@ -1,4 +1,8 @@
-package org.greatfire.envoy
+package org.greatfire.envoy.transport
+
+import org.greatfire.envoy.EnvoyConnectionTests
+import org.greatfire.envoy.EnvoyServiceType
+import org.greatfire.envoy.ShadowsocksService
 
 import android.content.Intent
 import android.util.Log

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/Transport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/Transport.kt
@@ -1,6 +1,6 @@
 package org.greatfire.envoy.transport
 
-import org.greatfire.envoy.EnvoyServiceType
+import org.greatfire.envoy.EnvoyTransportType
 import org.greatfire.envoy.EnvoyState
 import org.greatfire.envoy.UrlUtil
 
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit
 // for a PT, that gets stored in proxyUrl
 
 open class Transport(
-    var testType: EnvoyServiceType = EnvoyServiceType.UNKNOWN,
+    var testType: EnvoyTransportType = EnvoyTransportType.UNKNOWN,
     var url: String
 ) {
     companion object {

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/Transport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/Transport.kt
@@ -1,4 +1,8 @@
-package org.greatfire.envoy
+package org.greatfire.envoy.transport
+
+import org.greatfire.envoy.EnvoyServiceType
+import org.greatfire.envoy.EnvoyState
+import org.greatfire.envoy.UrlUtil
 
 import android.content.Context
 import android.content.Intent

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/V2SrtpTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/V2SrtpTransport.kt
@@ -1,7 +1,7 @@
 package org.greatfire.envoy.transport
 
 import org.greatfire.envoy.EnvoyConnectionTests
-import org.greatfire.envoy.EnvoyServiceType
+import org.greatfire.envoy.EnvoyTransportType
 
 import android.net.Uri
 import android.net.UrlQuerySanitizer
@@ -10,7 +10,7 @@ import android.util.Log
 import IEnvoyProxy.IEnvoyProxy
 import android.content.Context
 
-class V2SrtpTransport(url: String) : Transport(EnvoyServiceType.V2SRTP, url) {
+class V2SrtpTransport(url: String) : Transport(EnvoyTransportType.V2SRTP, url) {
 
     override suspend fun startTest(context: Context): Boolean {
         var addr = startService()

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/V2SrtpTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/V2SrtpTransport.kt
@@ -1,4 +1,7 @@
-package org.greatfire.envoy
+package org.greatfire.envoy.transport
+
+import org.greatfire.envoy.EnvoyConnectionTests
+import org.greatfire.envoy.EnvoyServiceType
 
 import android.net.Uri
 import android.net.UrlQuerySanitizer
@@ -7,10 +10,10 @@ import android.util.Log
 import IEnvoyProxy.IEnvoyProxy
 import android.content.Context
 
-class V2WechatTransport(url: String) : Transport(EnvoyServiceType.V2WECHAT, url) {
+class V2SrtpTransport(url: String) : Transport(EnvoyServiceType.V2SRTP, url) {
 
     override suspend fun startTest(context: Context): Boolean {
-        val addr = startService()
+        var addr = startService()
 
         if (addr == "") {
             // The go code doesn't handle failures well, but an empty
@@ -20,7 +23,7 @@ class V2WechatTransport(url: String) : Transport(EnvoyServiceType.V2WECHAT, url)
         }
 
         proxyUrl = "socks5://$addr"
-        Log.d(TAG, "testing V2Ray WeChat at ${proxyUrl}")
+        Log.d(TAG, "Testing V2Ray SRTP ${proxyUrl}")
 
         val res = testStandardProxy(Uri.parse(proxyUrl), testResponseCode)
         if (res == false) {
@@ -31,11 +34,11 @@ class V2WechatTransport(url: String) : Transport(EnvoyServiceType.V2WECHAT, url)
 
     override suspend fun startService(): String {
         if (serviceRunning) {
-            Log.e(TAG, "Tried to start V2ray Wechat when it was already running")
+            Log.e(TAG, "Tried to start V2ray Srtp when it was already running")
             return ""
         }
 
-        Log.d(TAG, "Starting service for V2ray Wechat")
+        Log.d(TAG, "Starting service for V2ray Srtp")
 
         serviceRunning = true
 
@@ -46,12 +49,8 @@ class V2WechatTransport(url: String) : Transport(EnvoyServiceType.V2WECHAT, url)
             it.v2RayServerPort = server.port.toString()
             it.v2RayId = getV2RayUuid(url)
 
-            val host = server.host
-            val port = server.port.toString()
-            val uuid = getV2RayUuid(url)
-
-            it.start(IEnvoyProxy.V2RayWechat, "")
-            val addr = it.localAddress(IEnvoyProxy.V2RayWechat)
+            it.start(IEnvoyProxy.V2RaySrtp, "")
+            val addr = it.localAddress(IEnvoyProxy.V2RaySrtp)
             EnvoyConnectionTests.isItUpYet(addr)
             return addr
         }
@@ -64,7 +63,7 @@ class V2WechatTransport(url: String) : Transport(EnvoyServiceType.V2WECHAT, url)
         // this is called to stop unused services
 
         state.iep?.let {
-            it.stop(IEnvoyProxy.V2RayWechat)
+            it.stop(IEnvoyProxy.V2RaySrtp)
         }
     }
 

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/V2WechatTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/V2WechatTransport.kt
@@ -1,7 +1,7 @@
 package org.greatfire.envoy.transport
 
 import org.greatfire.envoy.EnvoyConnectionTests
-import org.greatfire.envoy.EnvoyServiceType
+import org.greatfire.envoy.EnvoyTransportType
 
 import android.net.Uri
 import android.net.UrlQuerySanitizer
@@ -10,7 +10,7 @@ import android.util.Log
 import IEnvoyProxy.IEnvoyProxy
 import android.content.Context
 
-class V2WechatTransport(url: String) : Transport(EnvoyServiceType.V2WECHAT, url) {
+class V2WechatTransport(url: String) : Transport(EnvoyTransportType.V2WECHAT, url) {
 
     override suspend fun startTest(context: Context): Boolean {
         val addr = startService()

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/V2WechatTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/V2WechatTransport.kt
@@ -1,4 +1,7 @@
-package org.greatfire.envoy
+package org.greatfire.envoy.transport
+
+import org.greatfire.envoy.EnvoyConnectionTests
+import org.greatfire.envoy.EnvoyServiceType
 
 import android.net.Uri
 import android.net.UrlQuerySanitizer
@@ -7,10 +10,10 @@ import android.util.Log
 import IEnvoyProxy.IEnvoyProxy
 import android.content.Context
 
-class V2SrtpTransport(url: String) : Transport(EnvoyServiceType.V2SRTP, url) {
+class V2WechatTransport(url: String) : Transport(EnvoyServiceType.V2WECHAT, url) {
 
     override suspend fun startTest(context: Context): Boolean {
-        var addr = startService()
+        val addr = startService()
 
         if (addr == "") {
             // The go code doesn't handle failures well, but an empty
@@ -20,7 +23,7 @@ class V2SrtpTransport(url: String) : Transport(EnvoyServiceType.V2SRTP, url) {
         }
 
         proxyUrl = "socks5://$addr"
-        Log.d(TAG, "Testing V2Ray SRTP ${proxyUrl}")
+        Log.d(TAG, "testing V2Ray WeChat at ${proxyUrl}")
 
         val res = testStandardProxy(Uri.parse(proxyUrl), testResponseCode)
         if (res == false) {
@@ -31,11 +34,11 @@ class V2SrtpTransport(url: String) : Transport(EnvoyServiceType.V2SRTP, url) {
 
     override suspend fun startService(): String {
         if (serviceRunning) {
-            Log.e(TAG, "Tried to start V2ray Srtp when it was already running")
+            Log.e(TAG, "Tried to start V2ray Wechat when it was already running")
             return ""
         }
 
-        Log.d(TAG, "Starting service for V2ray Srtp")
+        Log.d(TAG, "Starting service for V2ray Wechat")
 
         serviceRunning = true
 
@@ -46,8 +49,12 @@ class V2SrtpTransport(url: String) : Transport(EnvoyServiceType.V2SRTP, url) {
             it.v2RayServerPort = server.port.toString()
             it.v2RayId = getV2RayUuid(url)
 
-            it.start(IEnvoyProxy.V2RaySrtp, "")
-            val addr = it.localAddress(IEnvoyProxy.V2RaySrtp)
+            val host = server.host
+            val port = server.port.toString()
+            val uuid = getV2RayUuid(url)
+
+            it.start(IEnvoyProxy.V2RayWechat, "")
+            val addr = it.localAddress(IEnvoyProxy.V2RayWechat)
             EnvoyConnectionTests.isItUpYet(addr)
             return addr
         }
@@ -60,7 +67,7 @@ class V2SrtpTransport(url: String) : Transport(EnvoyServiceType.V2SRTP, url) {
         // this is called to stop unused services
 
         state.iep?.let {
-            it.stop(IEnvoyProxy.V2RaySrtp)
+            it.stop(IEnvoyProxy.V2RayWechat)
         }
     }
 


### PR DESCRIPTION
This:
* moves Transport and its subclasses in a sub-namespace (`org.greatfire.envoy.transport`)
* renames EnvoyServiceType to EnvoyTransportType
* This is 100% just renaming things and adding imports except there's one minor change to simplify the code in `doWork`, I didn't know about `?.let` when I wrote that :)

I think the only question I have is how to order the imports... I've been keeping them alphabetical, that seems to be the convention, but I don't know if local imports are treated differently, I put them in a separate block as I do in Python ;-)