### PR TITLE
Disbale failing patches

### DIFF
--- a/native/02.5-update_api_01_02.patch
+++ b/native/02.5-update_api_01_02.patch
@@ -1,0 +1,39 @@
+ components/cronet/android/api.txt         | 6 +++++-
+ components/cronet/android/api_version.txt | 2 +-
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/components/cronet/android/api.txt b/components/cronet/android/api.txt
+index 66c254503684f..a0fbcd19ebc83 100644
+--- a/components/cronet/android/api.txt
++++ b/components/cronet/android/api.txt
+@@ -86,6 +86,8 @@ public class org.chromium.net.CronetEngine$Builder {
+   public static final int HTTP_CACHE_IN_MEMORY;
+   public static final int HTTP_CACHE_DISK_NO_HTTP;
+   public static final int HTTP_CACHE_DISK;
++  public org.chromium.net.CronetEngine$Builder setResolverRules(java.lang.String);
++  public org.chromium.net.CronetEngine$Builder setProxyUrl(java.lang.String);
+   public org.chromium.net.CronetEngine$Builder(android.content.Context);
+   public org.chromium.net.CronetEngine$Builder(org.chromium.net.ICronetEngineBuilder);
+   public java.lang.String getDefaultUserAgent();
+@@ -328,6 +330,8 @@ public abstract class org.chromium.net.ICronetEngineBuilder {
+   public abstract org.chromium.net.ICronetEngineBuilder setLibraryLoader(org.chromium.net.CronetEngine$Builder$LibraryLoader);
+   public abstract org.chromium.net.ICronetEngineBuilder setStoragePath(java.lang.String);
+   public abstract org.chromium.net.ICronetEngineBuilder setUserAgent(java.lang.String);
++  public abstract org.chromium.net.ICronetEngineBuilder setProxyUrl(java.lang.String);
++  public abstract org.chromium.net.ICronetEngineBuilder setResolverRules(java.lang.String);
+   public abstract java.lang.String getDefaultUserAgent();
+   public abstract org.chromium.net.ExperimentalCronetEngine build();
+   protected java.util.Set<java.lang.Integer> getSupportedConfigOptions();
+@@ -636,4 +640,4 @@ public class org.chromium.net.apihelpers.UrlRequestCallbacks {
+   public static org.chromium.net.apihelpers.JsonCronetCallback forJsonBody(org.chromium.net.apihelpers.RedirectHandler, org.chromium.net.apihelpers.CronetRequestCompletionListener<org.json.JSONObject>);
+   public static org.chromium.net.apihelpers.UrlRequestCallbacks$CallbackAndResponseFuturePair<org.json.JSONObject, org.chromium.net.apihelpers.JsonCronetCallback> forJsonBody(org.chromium.net.apihelpers.RedirectHandler);
+ }
+-Stamp: 373f90cf8fd10bf187e827fa2a4701af
++Stamp: a80ae673f70704a94016765782d0adab
+diff --git a/components/cronet/android/api_version.txt b/components/cronet/android/api_version.txt
+index bb95160cb6e07..a787364590245 100644
+--- a/components/cronet/android/api_version.txt
++++ b/components/cronet/android/api_version.txt
+@@ -1 +1 @@
+-33
++34

--- a/native/build_cronet.sh
+++ b/native/build_cronet.sh
@@ -24,9 +24,11 @@ git checkout .
 
 patch --fuzz=0 --no-backup-if-mismatch --forward --strip=1 --reject-file=- <"$PATCH_DIR/01-proxy_support.patch"
 patch --fuzz=0 --no-backup-if-mismatch --forward --strip=1 --reject-file=- <"$PATCH_DIR/02-dns_resolver_rules.patch"
-patch --fuzz=0 --no-backup-if-mismatch --forward --strip=1 --reject-file=- <"$PATCH_DIR/03-tls_options.patch"
-patch --fuzz=0 --no-backup-if-mismatch --forward --strip=1 --reject-file=- <"$PATCH_DIR/04-dns_over_https_config.patch"
-patch --fuzz=0 --no-backup-if-mismatch --forward --strip=1 --reject-file=- <"$PATCH_DIR/05-update_api.patch"
+patch --fuzz=0 --no-backup-if-mismatch --forward --strip=1 --reject-file=- <"$PATCH_DIR/02.5-update_api_01_02.patch"
+# the tls_options patch needs some fixes? cronet requests fail with it applied
+#patch --fuzz=0 --no-backup-if-mismatch --forward --strip=1 --reject-file=- <"$PATCH_DIR/03-tls_options.patch"
+#patch --fuzz=0 --no-backup-if-mismatch --forward --strip=1 --reject-file=- <"$PATCH_DIR/04-dns_over_https_config.patch"
+#patch --fuzz=0 --no-backup-if-mismatch --forward --strip=1 --reject-file=- <"$PATCH_DIR/05-update_api.patch"
 
 # XXX hacky fix of build problem in M128
 if [[ ! -L "$CHROMIUM_SRC_ROOT/buildtools/reclient_cfgs/chromium-browser-clang" ]]; then

--- a/native/checkout-to-tag.sh
+++ b/native/checkout-to-tag.sh
@@ -8,7 +8,7 @@ export DEPOT_TOOLS_UPDATE=0
 CHROMIUM_SRC_ROOT=${CHROMIUM_SRC_ROOT:-/root/chromium/src}
 DEPOT_TOOLS_ROOT=${DEPOT_TOOLS_ROOT:-/root/depot_tools}
 export PATH="$DEPOT_TOOLS_ROOT:$PATH"
-TAG=${1:-128.0.6537.2}
+TAG=${1:-128.0.6613.148}
 
 cd "$CHROMIUM_SRC_ROOT" || exit 1
 
@@ -23,7 +23,7 @@ cd "$DEPOT_TOOLS_ROOT" || exit 2
 git checkout main && git pull && git checkout "$(git rev-list -n 1 --before="$COMMIT_DATE" main)"
 
 cd "$CHROMIUM_SRC_ROOT" || exit 3
-git clean -ffd # --dry-run
+#git clean -ffd # --dry-run
 
 gclient sync --nohooks
 # Will prompt for package installation


### PR DESCRIPTION
This disables the TLS options and DNS config patches, for now at least. The TLS options needs some fixes

I also updated the version in checkout_to_tag