### PR TITLE
cleanup envoy and demo gradle files so they match where appropriate

### DIFF
--- a/android/demo/build.gradle
+++ b/android/demo/build.gradle
@@ -25,31 +25,43 @@ android {
     }
 
     defaultConfig {
-        applicationId 'com.example.myapplication'
+        compileSdk 34
         minSdkVersion 26
         targetSdkVersion 34
+
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        consumerProguardFiles 'consumer-rules.pro'
+
+        applicationId 'com.example.myapplication'
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
         ndk {
             abiFilters = ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
         }
     }
+
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
     compileOptions {
         sourceCompatibility = 1.8
         targetCompatibility = 1.8
     }
+
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+
     namespace 'com.example.myapplication'
+    buildFeatures {
+        buildConfig true
+    }
+
     packagingOptions {
         jniLibs {
             useLegacyPackaging true
@@ -60,22 +72,24 @@ android {
 }
 
 dependencies {
-    implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.0"))
+    // resolves duplicate class error from earlier kotlin bom version
+    implementation(platform('org.jetbrains.kotlin:kotlin-bom:2.1.20'))
 
-    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+
+    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
 
     implementation 'com.google.protobuf:protobuf-javalite:4.31.1'
 
     implementation project(path: ':envoy')
-//    implementation 'org.greatfire.envoy:cronet:108.0.5359.195'
-    //implementation 'org.greatfire.envoy:cronet:107.0.5304.150-1'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
     implementation 'com.google.android.material:material:1.11.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
 
+    // comment/uncomment depending on whether maven or local files are used
+    // implementation 'org.greatfire.envoy:cronet:108.0.5359.195'
+    debugApi(name: 'cronet-debug', ext: 'aar')
+    releaseApi(name: 'cronet-release', ext: 'aar')
     debugApi(name: 'IEnvoyProxy', ext: 'aar')
     releaseApi(name: 'IEnvoyProxy', ext: 'aar')
-    debugApi(name: 'cronet-debug', ext: 'aar')
-    //releaseApi(name: 'cronet-release', ext: 'aar')
 }

--- a/android/envoy/build.gradle
+++ b/android/envoy/build.gradle
@@ -20,45 +20,36 @@ android {
         }
     }
 
-    sourceSets {
-        main {
-            java.srcDirs = ['src/main/kotlin',]
-            jniLibs.srcDirs = ['../cronet']
-        }
-    }
     compileOptions {
         sourceCompatibility = 1.8
         targetCompatibility = 1.8
     }
+
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+
     namespace 'org.greatfire.envoy'
     buildFeatures {
         buildConfig true
     }
+
     compileSdk 35
 }
 
 dependencies {
-    // resolves duplicate class error
+    // resolves duplicate class error from earlier kotlin bom version
     implementation(platform('org.jetbrains.kotlin:kotlin-bom:2.1.20'))
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:2.1.20'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2'
-
     implementation('androidx.work:work-runtime-ktx:2.10.0')
-
-    testImplementation 'junit:junit:4.12'
 
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.12.0'
-//    implementation 'com.squareup.okhttp3:okhttp-dnsoverhttps:4.12.0'
 
     implementation 'androidx.core:core-ktx:1.16.0'
     implementation 'androidx.preference:preference-ktx:1.2.1'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
-
-    // implementation 'org.greatfire:IEnvoyProxy:3.5.0'
 
     implementation 'tech.relaycorp:doh:1.0.70'
 
@@ -68,10 +59,14 @@ dependencies {
     debugApi(name: 'lib-ohttp-plugin-release', ext: 'aar')
     releaseApi(name: 'lib-ohttp-plugin-release', ext: 'aar')
 
+    // comment/uncomment depending on whether maven or local files are used
+    // implementation 'org.greatfire.envoy:cronet:108.0.5359.195'
     debugApi(name: 'cronet-debug', ext: 'aar')
     releaseApi(name: 'cronet-release', ext: 'aar')
     debugApi(name: 'IEnvoyProxy', ext: 'aar')
     releaseApi(name: 'IEnvoyProxy', ext: 'aar')
+
+    testImplementation 'junit:junit:4.12'
 }
 
 def stdout = new ByteArrayOutputStream()


### PR DESCRIPTION
attempting to solve this issue: https://github.com/greatfire/envoy/issues/125

only the demo uses the hiddensecrets library to decode our urls.  this has several effects:
 - envoy/library and demo/application correspond to what type of output we're building
 - the following buildscript/repositories/dependencies block in demo is required by hiddensecrets
 - the same goes for the externalNativeBuild block
 - also applicationId, abiFilters
 - also packagingOptions

only the envoy library requires the zip/publish sections.  i've had limited interaction with these so i'm not sure what their status is.  i'm inclined to leave this part alone
 
dependencies differ between projects, mostly in terms of envoy having more dependencies than the demo.  where the same dependency was in both i changed them to the same version.

i removed sourceSets.  it included only the default since there isn't any difference between build variants.

i was able to build envoy and run the demo, so i don't think i broke anything.