### PR TITLE
change cache parameter to reflect cronet patch

### DIFF
--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyInterceptor.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/EnvoyInterceptor.kt
@@ -146,7 +146,14 @@ class EnvoyInterceptor : Interceptor {
                 // add param to create unique url and avoid cached response
                 // method based on patched cronet code in url_request_http_job.cc
                 val url = req.url
-                val uniqueString = url.toString() + Random.Default.nextBytes(16).decodeToString()
+
+                var salt = Random.Default.nextBytes(16).decodeToString()
+                // check for existing salt param
+                url.queryParameter("salt")?.let {
+                   salt = it
+                }
+
+                val uniqueString = url.toString() + salt
                 val sha256String = MessageDigest.getInstance("SHA-256").digest(uniqueString.toByteArray()).decodeToString()
                 val encodedString = URLEncoder.encode(sha256String, "UTF-8")
                 with (builder) {

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/OkHttpEnvoyTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/OkHttpEnvoyTransport.kt
@@ -19,9 +19,16 @@ class OkHttpEnvoyTransport(url: String) : Transport(EnvoyTransportType.OKHTTP_EN
             return false
         }
 
+        var salt = Random.Default.nextBytes(16).decodeToString()
+        // check for existing salt param
+        val tempUri = Uri.parse(url)
+        tempUri.getQueryParameter("salt")?.let {
+            salt = it
+        }
+
         // add param to create unique url and avoid cached response
         // method based on patched cronet code in url_request_http_job.cc
-        val uniqueString = url + Random.Default.nextBytes(16).decodeToString()
+        val uniqueString = url + salt
         val sha256String = MessageDigest.getInstance("SHA-256").digest(uniqueString.toByteArray()).decodeToString()
         val encodedString = URLEncoder.encode(sha256String, "UTF-8")
         val tempUrl = url + "?digest=" + encodedString

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/OkHttpProxyTransport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/OkHttpProxyTransport.kt
@@ -21,9 +21,16 @@ class OkHttpProxyTransport(url: String) : Transport(EnvoyTransportType.OKHTTP_PR
             return false
         }
 
+        var salt = Random.Default.nextBytes(16).decodeToString()
+        // check for existing salt param
+        val tempUri = Uri.parse(url)
+        tempUri.getQueryParameter("salt")?.let {
+            salt = it
+        }
+
         // add param to create unique url and avoid cached response
         // method based on patched cronet code in url_request_http_job.cc
-        val uniqueString = url + Random.Default.nextBytes(16).decodeToString()
+        val uniqueString = url + salt
         val sha256String = MessageDigest.getInstance("SHA-256").digest(uniqueString.toByteArray()).decodeToString()
         val encodedString = URLEncoder.encode(sha256String, "UTF-8")
         val url = proxyUrl.toString() + "?digest=" + encodedString


### PR DESCRIPTION
This is meant to address this issue: https://github.com/greatfire/envoy/issues/133

The envoy code currently uses the current time as a parameter to create a unique url.  This PR changes the envoy code to use the same method as the patched cronet code here: https://github.com/greatfire/envoy/blob/master/native/0001-Envoy.patch#L782
