### PR TITLE
updated some patches to use experimental options

### DIFF
--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/CronetNetworking.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/CronetNetworking.kt
@@ -46,7 +46,7 @@ object CronetNetworking {
             builder = builder.setProxyUrl(proxyUrl)
         }
         if (resolverRules.isNotEmpty()) {
-            builder = builder.setResolverRules(resolverRules)
+            builder = builder.setExperimentalOptions(resolverRules)
         }
         // XXX TLS options here, if we support them
 

--- a/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/Transport.kt
+++ b/android/envoy/src/main/kotlin/org/greatfire/envoy/transport/Transport.kt
@@ -65,6 +65,9 @@ open class Transport(
     val headers = mutableListOf<Pair<String, String>>()
     // address param creates an resolver rule
     // stash it here in case we can support it with OkHttp
+    // resolver rules in experimental options must be in json format
+    // ie: "{\"resolver_rules\": \"MAP <URL> <IP>, <...> \"}"
+    // TODO: build JSON object and convert to string?
     var address: String? = null
     var resolverRules: String = ""
 

--- a/native/02-dns_resolver_rules.patch
+++ b/native/02-dns_resolver_rules.patch
@@ -1,417 +1,86 @@
- .../android/api/src/org/chromium/net/CronetEngine.java  |  9 +++++++++
- .../api/src/org/chromium/net/ICronetEngineBuilder.java  |  2 ++
- components/cronet/android/cronet_context_adapter.cc     |  1 +
- .../net/impl/AndroidHttpEngineBuilderWrapper.java       |  7 +++++++
- .../org/chromium/net/impl/CronetEngineBuilderImpl.java  | 11 +++++++++++
- .../org/chromium/net/impl/CronetUrlRequestContext.java  |  4 ++++
- .../cronet/android/proto/request_context_config.proto   |  1 +
- .../cronet_sample_apk/CronetSampleApplication.java      |  2 ++
- .../net/ExperimentalOptionsTranslationTestUtil.java     |  5 +++++
- components/cronet/native/cronet.idl                     |  6 ++++++
- components/cronet/native/engine.cc                      |  1 +
- components/cronet/native/generated/cronet.idl_c.h       |  6 ++++++
- .../cronet/native/generated/cronet.idl_impl_struct.cc   | 12 ++++++++++++
- .../cronet/native/generated/cronet.idl_impl_struct.h    |  1 +
- components/cronet/native/sample/main.cc                 |  1 +
- components/cronet/url_request_context_config.cc         |  8 ++++++--
- components/cronet/url_request_context_config.h          |  9 +++++++++
- net/url_request/url_request_context.h                   |  5 +++++
- net/url_request/url_request_context_builder.cc          | 17 ++++++++++++++++-
- net/url_request/url_request_context_builder.h           |  6 ++++++
- 20 files changed, 111 insertions(+), 3 deletions(-)
+ components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleApplication.java |  2 ++
+ components/cronet/native/sample/main.cc                                                          |  1 +
+ components/cronet/url_request_context_config.cc                                                  | 12 ++++++++++++
+ net/url_request/url_request_context_builder.cc                                                   | 17 ++++++++++++++++-
+ net/url_request/url_request_context_builder.h                                                    |  7 +++++++
+ 5 files changed, 38 insertions(+), 1 deletion(-)
 
-diff --git a/components/cronet/android/api/src/org/chromium/net/CronetEngine.java b/components/cronet/android/api/src/org/chromium/net/CronetEngine.java
-index 52f40c923b796..d97ae131dc6f1 100644
---- a/components/cronet/android/api/src/org/chromium/net/CronetEngine.java
-+++ b/components/cronet/android/api/src/org/chromium/net/CronetEngine.java
-@@ -135,6 +135,15 @@ public abstract class CronetEngine {
-         /** Reference to the actual builder implementation. {@hide exclude from JavaDoc}. */
-         protected final ICronetEngineBuilder mBuilderDelegate;
- 
-+        /**
-+         * A string argument to be passed into MappedHostResolver->SetRulesFromString. It can
-+         * be used to create direct mappings from domains to ips that override dns lookups.
-+         */
-+        public Builder setResolverRules(String resolverRules) {
-+            mBuilderDelegate.setResolverRules(resolverRules);
-+            return this;
-+        }
-+
-         /**
-          *
-          *
-diff --git a/components/cronet/android/api/src/org/chromium/net/ICronetEngineBuilder.java b/components/cronet/android/api/src/org/chromium/net/ICronetEngineBuilder.java
-index 427d0d0c224f6..0dd5753e64404 100644
---- a/components/cronet/android/api/src/org/chromium/net/ICronetEngineBuilder.java
-+++ b/components/cronet/android/api/src/org/chromium/net/ICronetEngineBuilder.java
-@@ -77,6 +77,8 @@ public abstract class ICronetEngineBuilder {
- 
-     public abstract ICronetEngineBuilder setProxyUrl(String proxy_url);
- 
-+    public abstract ICronetEngineBuilder setResolverRules(String resolverRules);
-+
-     public abstract String getDefaultUserAgent();
- 
-     public abstract ExperimentalCronetEngine build();
-diff --git a/components/cronet/android/cronet_context_adapter.cc b/components/cronet/android/cronet_context_adapter.cc
-index adf42f3e013f2..ce696deaa53c4 100644
---- a/components/cronet/android/cronet_context_adapter.cc
-+++ b/components/cronet/android/cronet_context_adapter.cc
-@@ -254,6 +254,7 @@ static jlong JNI_CronetUrlRequestContext_CreateRequestContextConfig(
-           configOptions.storage_path(),
-           /* accept_languages */ std::string(), configOptions.user_agent(),
-           configOptions.proxy_url(),
-+          configOptions.resolver_rules(),
-           configOptions.experimental_options(),
-           base::WrapUnique(reinterpret_cast<net::CertVerifier*>(
-               configOptions.mock_cert_verifier())),
-diff --git a/components/cronet/android/java/src/org/chromium/net/impl/AndroidHttpEngineBuilderWrapper.java b/components/cronet/android/java/src/org/chromium/net/impl/AndroidHttpEngineBuilderWrapper.java
-index e33dee1639916..ec2d4ef033ff6 100644
---- a/components/cronet/android/java/src/org/chromium/net/impl/AndroidHttpEngineBuilderWrapper.java
-+++ b/components/cronet/android/java/src/org/chromium/net/impl/AndroidHttpEngineBuilderWrapper.java
-@@ -56,6 +56,13 @@ class AndroidHttpEngineBuilderWrapper extends ICronetEngineBuilder {
-         return this;
-     }
- 
-+    @Override
-+    public ICronetEngineBuilder setResolverRules(String resolverRules) {
-+        // HttpEngine.Builder doesn't have this method
-+        // mBackend.setResolverRules(resolverRules);
-+        return this;
-+    }
-+
-     @Override
-     public ICronetEngineBuilder setStoragePath(String value) {
-         mBackend.setStoragePath(value);
-diff --git a/components/cronet/android/java/src/org/chromium/net/impl/CronetEngineBuilderImpl.java b/components/cronet/android/java/src/org/chromium/net/impl/CronetEngineBuilderImpl.java
-index 6511b87d30ab5..6bf8d9a1ea536 100644
---- a/components/cronet/android/java/src/org/chromium/net/impl/CronetEngineBuilderImpl.java
-+++ b/components/cronet/android/java/src/org/chromium/net/impl/CronetEngineBuilderImpl.java
-@@ -143,6 +143,7 @@ public abstract class CronetEngineBuilderImpl extends ICronetEngineBuilder {
-     private boolean mPublicKeyPinningBypassForLocalTrustAnchorsEnabled;
-     private String mUserAgent;
-     private String mProxyUrl;
-+    private String mResolverRules;
-     private String mStoragePath;
-     private boolean mQuicEnabled;
-     private boolean mHttp2Enabled;
-@@ -243,6 +244,16 @@ public abstract class CronetEngineBuilderImpl extends ICronetEngineBuilder {
-         return mProxyUrl;
-     }
- 
-+    @Override
-+    public CronetEngineBuilderImpl setResolverRules(String resolverRules) {
-+        mResolverRules = resolverRules;
-+        return this;
-+    }
-+
-+    public String getResolverRules() {
-+        return mResolverRules;
-+    }
-+
-     @Override
-     public CronetEngineBuilderImpl setStoragePath(String value) {
-         if (!new File(value).isDirectory()) {
-diff --git a/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java b/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java
-index 429c2c728df73..690b2d4e8d1c6 100644
---- a/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java
-+++ b/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java
-@@ -423,6 +423,10 @@ public class CronetUrlRequestContext extends CronetEngineBase {
-             resultBuilder.setProxyUrl(engineBuilder.getProxyUrl());
-         }
- 
-+        if (engineBuilder.getResolverRules() != null) {
-+            resultBuilder.setResolverRules(engineBuilder.getResolverRules());
-+        }
-+
-         return resultBuilder.build();
-     }
- 
-diff --git a/components/cronet/android/proto/request_context_config.proto b/components/cronet/android/proto/request_context_config.proto
-index f73db98ddc54c..6d9df5f9ebcd9 100644
---- a/components/cronet/android/proto/request_context_config.proto
-+++ b/components/cronet/android/proto/request_context_config.proto
-@@ -22,4 +22,5 @@ message RequestContextConfigOptions {
-   optional bool bypass_public_key_pinning_for_local_trust_anchors = 13;
-   optional int32 network_thread_priority = 14;
-   optional string proxy_url = 15;
-+  optional string resolver_rules = 16;
- }
 diff --git a/components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleApplication.java b/components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleApplication.java
-index 7e1b0d448c621..c8c06e94ee7a5 100644
+index 87436d5a2d90c..bc714727729cc 100644
 --- a/components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleApplication.java
 +++ b/components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleApplication.java
-@@ -25,6 +25,7 @@ public class CronetSampleApplication extends Application {
+@@ -24,6 +24,7 @@ public class CronetSampleApplication extends Application {
+         myBuilder
                  .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_IN_MEMORY, 100 * 1024)
                  .enableHttp2(true)
-                 .setProxyUrl("socks5://127.0.0.1:1080")
-+                .setResolverRules("MAP * 208.80.154.224")
++                .setExperimentalOptions("{\"resolver_rules\": \"MAP * 65.21.79.229, EXCLUDE *.google.*\"}")
                  .enableQuic(true);
          mCronetEngine = myBuilder.build();
      }
-@@ -64,6 +65,7 @@ public class CronetSampleApplication extends Application {
+@@ -62,6 +63,7 @@ public class CronetSampleApplication extends Application {
+                         .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_IN_MEMORY, 100 * 1024)
                          .enableHttp2(true)
                          .enableQuic(true)
-                         .setProxyUrl("socks5://127.0.0.1:1080")
-+                        .setResolverRules("MAP * 208.80.154.224")
++                        .setExperimentalOptions("{\"resolver_rules\": \"MAP * 65.21.79.229, EXCLUDE *.google.*\"}")
                          .build();
      }
  }
-diff --git a/components/cronet/android/test/javatests/src/org/chromium/net/ExperimentalOptionsTranslationTestUtil.java b/components/cronet/android/test/javatests/src/org/chromium/net/ExperimentalOptionsTranslationTestUtil.java
-index 82921ef41d97c..27455a11f4553 100644
---- a/components/cronet/android/test/javatests/src/org/chromium/net/ExperimentalOptionsTranslationTestUtil.java
-+++ b/components/cronet/android/test/javatests/src/org/chromium/net/ExperimentalOptionsTranslationTestUtil.java
-@@ -195,6 +195,11 @@ public class ExperimentalOptionsTranslationTestUtil {
-             throw new UnsupportedOperationException();
-         }
- 
-+        @Override
-+        public ICronetEngineBuilder setResolverRules(String value) {
-+            throw new UnsupportedOperationException();
-+        }
-+
-         @Override
-         public ICronetEngineBuilder setConnectionMigrationOptions(
-                 ConnectionMigrationOptions options) {
-diff --git a/components/cronet/native/cronet.idl b/components/cronet/native/cronet.idl
-index 0f8aa13af59d1..d991bcb3277b4 100644
---- a/components/cronet/native/cronet.idl
-+++ b/components/cronet/native/cronet.idl
-@@ -511,6 +511,12 @@ struct EngineParams {
-    */
-   string user_agent;
- 
-+  /**
-+   * A string argument to be passed into MappedHostResolver->SetRulesFromString. It can
-+   * be used to create direct mappings from domains to ips that override dns lookups.
-+   */
-+  string resolver_rules;
-+
-   /**
-    *
-    *
-diff --git a/components/cronet/native/engine.cc b/components/cronet/native/engine.cc
-index 0bd1f623f3705..1590dda780a2a 100644
---- a/components/cronet/native/engine.cc
-+++ b/components/cronet/native/engine.cc
-@@ -150,6 +150,7 @@ Cronet_RESULT Cronet_EngineImpl::StartWithParams(
-   context_config_builder.accept_language = params->accept_language;
-   context_config_builder.user_agent = params->user_agent;
-   context_config_builder.proxy_url = params->proxy_url;
-+  context_config_builder.resolver_rules = params->resolver_rules;
-   context_config_builder.experimental_options = params->experimental_options;
-   context_config_builder.bypass_public_key_pinning_for_local_trust_anchors =
-       params->enable_public_key_pinning_bypass_for_local_trust_anchors;
-diff --git a/components/cronet/native/generated/cronet.idl_c.h b/components/cronet/native/generated/cronet.idl_c.h
-index b451cdc686f06..76822f773a0c4 100644
---- a/components/cronet/native/generated/cronet.idl_c.h
-+++ b/components/cronet/native/generated/cronet.idl_c.h
-@@ -798,6 +798,9 @@ CRONET_EXPORT
- void Cronet_EngineParams_proxy_url_set(Cronet_EngineParamsPtr self,
-                                         const Cronet_String proxy_url);
- CRONET_EXPORT
-+void Cronet_EngineParams_resolver_rules_set(Cronet_EngineParamsPtr self,
-+                                        const Cronet_String resolver_rules);
-+CRONET_EXPORT
- void Cronet_EngineParams_accept_language_set(
-     Cronet_EngineParamsPtr self,
-     const Cronet_String accept_language);
-@@ -851,6 +854,9 @@ CRONET_EXPORT
- Cronet_String Cronet_EngineParams_proxy_url_get(
-     const Cronet_EngineParamsPtr self);
- CRONET_EXPORT
-+Cronet_String Cronet_EngineParams_resolver_rules_get(
-+    const Cronet_EngineParamsPtr self);
-+CRONET_EXPORT
- Cronet_String Cronet_EngineParams_accept_language_get(
-     const Cronet_EngineParamsPtr self);
- CRONET_EXPORT
-diff --git a/components/cronet/native/generated/cronet.idl_impl_struct.cc b/components/cronet/native/generated/cronet.idl_impl_struct.cc
-index eb598226660d9..5f19a306b0ec1 100644
---- a/components/cronet/native/generated/cronet.idl_impl_struct.cc
-+++ b/components/cronet/native/generated/cronet.idl_impl_struct.cc
-@@ -255,6 +255,12 @@ void Cronet_EngineParams_proxy_url_set(Cronet_EngineParamsPtr self,
-   self->proxy_url = proxy_url;
- }
- 
-+void Cronet_EngineParams_resolver_rules_set(Cronet_EngineParamsPtr self,
-+                                        const Cronet_String resolver_rules) {
-+  DCHECK(self);
-+  self->resolver_rules = resolver_rules;
-+}
-+
- void Cronet_EngineParams_accept_language_set(
-     Cronet_EngineParamsPtr self,
-     const Cronet_String accept_language) {
-@@ -354,6 +360,12 @@ Cronet_String Cronet_EngineParams_proxy_url_get(
-   return self->proxy_url.c_str();
- }
- 
-+Cronet_String Cronet_EngineParams_resolver_rules_get(
-+    const Cronet_EngineParamsPtr self) {
-+  DCHECK(self);
-+  return self->resolver_rules.c_str();
-+}
-+
- Cronet_String Cronet_EngineParams_accept_language_get(
-     const Cronet_EngineParamsPtr self) {
-   DCHECK(self);
-diff --git a/components/cronet/native/generated/cronet.idl_impl_struct.h b/components/cronet/native/generated/cronet.idl_impl_struct.h
-index 1677263ce638f..3694104c6ce92 100644
---- a/components/cronet/native/generated/cronet.idl_impl_struct.h
-+++ b/components/cronet/native/generated/cronet.idl_impl_struct.h
-@@ -83,6 +83,7 @@ struct Cronet_EngineParams {
-   bool enable_check_result = true;
-   std::string user_agent;
-   std::string proxy_url;
-+  std::string resolver_rules;
-   std::string accept_language;
-   std::string storage_path;
-   bool enable_quic = true;
 diff --git a/components/cronet/native/sample/main.cc b/components/cronet/native/sample/main.cc
-index 2e8aa0e81863f..a484ac5ab9482 100644
+index fe9ff6f1ee279..25503195fe04c 100644
 --- a/components/cronet/native/sample/main.cc
 +++ b/components/cronet/native/sample/main.cc
-@@ -13,6 +13,7 @@ Cronet_EnginePtr CreateCronetEngine() {
+@@ -17,6 +17,7 @@ Cronet_EnginePtr CreateCronetEngine() {
+   Cronet_EnginePtr cronet_engine = Cronet_Engine_Create();
    Cronet_EngineParamsPtr engine_params = Cronet_EngineParams_Create();
    Cronet_EngineParams_user_agent_set(engine_params, "CronetSample/1");
-   Cronet_EngineParams_proxy_url_set(engine_params, "socks5://127.0.0.1:1080");
-+  Cronet_EngineParams_resolver_rules_set(engine_params, "MAP * 208.80.154.224");
++  Cronet_EngineParams_experimental_options_set(engine_params, "{\"resolver_rules\": \"MAP * 65.21.79.229, EXCLUDE *.google.*\"}");
    Cronet_EngineParams_enable_quic_set(engine_params, true);
  
    Cronet_Engine_StartWithParams(cronet_engine, engine_params);
 diff --git a/components/cronet/url_request_context_config.cc b/components/cronet/url_request_context_config.cc
-index ba2df8a3d2ec6..3c0c0aee2eb96 100644
+index 8da024badd93a..33b2c57f02391 100644
 --- a/components/cronet/url_request_context_config.cc
 +++ b/components/cronet/url_request_context_config.cc
-@@ -265,6 +265,7 @@ URLRequestContextConfig::URLRequestContextConfig(
-     const std::string& accept_language,
-     const std::string& user_agent,
-     const std::string& proxy_url,
-+    const std::string& resolver_rules,
-     base::Value::Dict experimental_options,
-     std::unique_ptr<net::CertVerifier> mock_cert_verifier,
-     bool enable_network_quality_estimator,
-@@ -280,6 +281,7 @@ URLRequestContextConfig::URLRequestContextConfig(
-       accept_language(accept_language),
-       user_agent(user_agent),
-       proxy_url(proxy_url),
-+      resolver_rules(resolver_rules),
-       mock_cert_verifier(std::move(mock_cert_verifier)),
-       enable_network_quality_estimator(enable_network_quality_estimator),
-       bypass_public_key_pinning_for_local_trust_anchors(
-@@ -307,6 +309,7 @@ URLRequestContextConfig::CreateURLRequestContextConfig(
-     const std::string& accept_language,
-     const std::string& user_agent,
-     const std::string& proxy_url,
-+    const std::string& resolver_rules,
-     const std::string& unparsed_experimental_options,
-     std::unique_ptr<net::CertVerifier> mock_cert_verifier,
-     bool enable_network_quality_estimator,
-@@ -324,7 +327,7 @@ URLRequestContextConfig::CreateURLRequestContextConfig(
-   }
-   return base::WrapUnique(new URLRequestContextConfig(
-       enable_quic, enable_spdy, enable_brotli, http_cache, http_cache_max_size,
--      load_disable_cache, storage_path, accept_language, user_agent, proxy_url,
-+      load_disable_cache, storage_path, accept_language, user_agent, proxy_url, resolver_rules,
-       std::move(experimental_options).value(), std::move(mock_cert_verifier),
-       enable_network_quality_estimator,
-       bypass_public_key_pinning_for_local_trust_anchors,
-@@ -803,6 +806,7 @@ void URLRequestContextConfig::ConfigureURLRequestContextBuilder(
-   context_builder->set_accept_language(accept_language);
-   context_builder->set_user_agent(user_agent);
-   context_builder->set_proxy_url(proxy_url);
-+  context_builder->set_resolver_rules(resolver_rules);
-   net::HttpNetworkSessionParams session_params;
-   session_params.enable_http2 = enable_spdy;
-   session_params.enable_quic = enable_quic;
-@@ -832,7 +836,7 @@ std::unique_ptr<URLRequestContextConfig>
- URLRequestContextConfigBuilder::Build() {
-   return URLRequestContextConfig::CreateURLRequestContextConfig(
-       enable_quic, enable_spdy, enable_brotli, http_cache, http_cache_max_size,
--      load_disable_cache, storage_path, accept_language, user_agent, proxy_url,
-+      load_disable_cache, storage_path, accept_language, user_agent, proxy_url, resolver_rules,
-       experimental_options, std::move(mock_cert_verifier),
-       enable_network_quality_estimator,
-       bypass_public_key_pinning_for_local_trust_anchors,
-diff --git a/components/cronet/url_request_context_config.h b/components/cronet/url_request_context_config.h
-index 4cab2d0935c82..11f8fe4c8f4c9 100644
---- a/components/cronet/url_request_context_config.h
-+++ b/components/cronet/url_request_context_config.h
-@@ -130,6 +130,9 @@ struct URLRequestContextConfig {
-   // URL of proxy server
-   const std::string proxy_url;
+@@ -211,6 +211,9 @@ const char kDisableTlsZeroRtt[] = "disable_tls_zero_rtt";
+ // underlying OS.
+ const char kSpdyGoAwayOnIpChange[] = "spdy_go_away_on_ip_change";
  
-+  // MappedHostResolver->SetRulesFromString argument
-+  const std::string resolver_rules;
++// DNS options
++const char kResolverRules[] = "resolver_rules";
 +
-   // Certificate verifier for testing.
-   std::unique_ptr<net::CertVerifier> mock_cert_verifier;
- 
-@@ -204,6 +207,8 @@ struct URLRequestContextConfig {
-       const std::string& user_agent,
-       // URL of proxy server
-       const std::string& proxy_url,
-+      // MappedHostResolver->SetRulesFromString argument
-+      const std::string& resolver_rules,
-       // JSON encoded experimental options.
-       const std::string& unparsed_experimental_options,
-       // MockCertVerifier to use for testing purposes.
-@@ -240,6 +245,8 @@ struct URLRequestContextConfig {
-       const std::string& user_agent,
-       // URL of proxy
-       const std::string& proxy_url,
-+      // MappedHostResolver->SetRulesFromString argument
-+      const std::string& resolver_rules,
-       // Parsed experimental options.
-       base::Value::Dict experimental_options,
-       // MockCertVerifier to use for testing purposes.
-@@ -310,6 +317,8 @@ struct URLRequestContextConfigBuilder {
-   std::string user_agent = "";
-   // URL of proxy
-   std::string proxy_url = "";
-+  // MappedHostResolver->SetRulesFromString argument
-+  std::string resolver_rules = "";
-   // Experimental options encoded as a string in a JSON format containing
-   // experiments and their corresponding configuration options. The format
-   // is a JSON object with the name of the experiment as the key, and the
-diff --git a/net/url_request/url_request_context.h b/net/url_request/url_request_context.h
-index 1b5fe91826c5f..aaeb51d510fd4 100644
---- a/net/url_request/url_request_context.h
-+++ b/net/url_request/url_request_context.h
-@@ -238,6 +238,9 @@ class NET_EXPORT URLRequestContext final {
-   void set_proxy_url(const std::string& proxy_url) { proxy_url_ = proxy_url; }
-   const std::string& proxy_url() const { return proxy_url_; }
- 
-+  void set_resolver_rules(const std::string& resolver_rules) { resolver_rules_ = resolver_rules; }
-+  const std::string& resolver_rules() const { return resolver_rules_; }
-+
-   void AssertCalledOnValidThread() {
-     DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-   }
-@@ -388,6 +391,8 @@ class NET_EXPORT URLRequestContext final {
- 
-   std::string proxy_url_;
- 
-+  std::string resolver_rules_;
-+
-   std::optional<std::string> cookie_deprecation_label_;
- 
-   handles::NetworkHandle bound_network_;
+ // Whether the connection status of all bidirectional streams (created through
+ // the Cronet engine) should be monitored.
+ // The value must be an integer (> 0) and will be interpreted as a suggestion
+@@ -765,6 +768,15 @@ void URLRequestContextConfig::SetContextBuilderExperimentalOptions(
+         continue;
+       }
+       session_params->spdy_go_away_on_ip_change = iter->second.GetBool();
++    } else if (iter->first == kResolverRules) {
++      if (!iter->second.is_string()) {
++        LOG(ERROR) << "\"" << iter->first << "\" config params \""
++                   << iter->second << "\" is not a string";
++        effective_experimental_options.Remove(iter->first);
++        continue;
++      }
++      std::string temp_resolver_rules = iter->second.GetString();
++      context_builder->set_resolver_rules(temp_resolver_rules);
+     } else {
+       LOG(WARNING) << "Unrecognized Cronet experimental option \""
+                    << iter->first << "\" with params \"" << iter->second;
 diff --git a/net/url_request/url_request_context_builder.cc b/net/url_request/url_request_context_builder.cc
-index 1abe519008ba3..7762dce872344 100644
+index 4ac56ba26747c..98864c9c04ddd 100644
 --- a/net/url_request/url_request_context_builder.cc
 +++ b/net/url_request/url_request_context_builder.cc
-@@ -31,6 +31,7 @@
- #include "net/dns/context_host_resolver.h"
+@@ -34,6 +34,7 @@
  #include "net/dns/host_resolver.h"
  #include "net/dns/host_resolver_manager.h"
+ #include "net/dns/stale_host_resolver.h"
 +#include "net/dns/mapped_host_resolver.h"
  #include "net/http/http_auth_handler_factory.h"
  #include "net/http/http_cache.h"
  #include "net/http/http_network_layer.h"
-@@ -132,6 +133,10 @@ void URLRequestContextBuilder::set_proxy_url(const std::string& proxy_url) {
-   proxy_url_ = proxy_url;
+@@ -133,6 +134,10 @@ void URLRequestContextBuilder::set_user_agent(const std::string& user_agent) {
+   user_agent_ = user_agent;
  }
  
 +void URLRequestContextBuilder::set_resolver_rules(const std::string& resolver_rules) {
@@ -421,7 +90,7 @@ index 1abe519008ba3..7762dce872344 100644
  void URLRequestContextBuilder::set_http_user_agent_settings(
      std::unique_ptr<HttpUserAgentSettings> http_user_agent_settings) {
    http_user_agent_settings_ = std::move(http_user_agent_settings);
-@@ -377,7 +382,17 @@ std::unique_ptr<URLRequestContext> URLRequestContextBuilder::Build() {
+@@ -376,7 +381,17 @@ std::unique_ptr<URLRequestContext> URLRequestContextBuilder::Build() {
      }
    }
    host_resolver_->SetRequestContext(context.get());
@@ -441,12 +110,12 @@ index 1abe519008ba3..7762dce872344 100644
    if (ssl_config_service_) {
      context->set_ssl_config_service(std::move(ssl_config_service_));
 diff --git a/net/url_request/url_request_context_builder.h b/net/url_request/url_request_context_builder.h
-index dfd0395f2fa4b..222bcc58037db 100644
+index 7a9022b3d789c..87c8be12eb921 100644
 --- a/net/url_request/url_request_context_builder.h
 +++ b/net/url_request/url_request_context_builder.h
-@@ -214,6 +214,11 @@ class NET_EXPORT URLRequestContextBuilder {
-   //
-   void set_proxy_url(const std::string& proxy_url);
+@@ -220,6 +220,11 @@ class NET_EXPORT URLRequestContextBuilder {
+   void set_accept_language(const std::string& accept_language);
+   void set_user_agent(const std::string& user_agent);
  
 +  // Sets a string argument to be passed into MappedHostResolver->
 +  // SetRulesFromString. It can be used to create direct mappings
@@ -456,11 +125,12 @@ index dfd0395f2fa4b..222bcc58037db 100644
    // Makes the created URLRequestContext use a particular HttpUserAgentSettings
    // object. Not compatible with set_accept_language() / set_user_agent().
    //
-@@ -439,6 +444,7 @@ class NET_EXPORT URLRequestContextBuilder {
+@@ -471,6 +476,8 @@ class NET_EXPORT URLRequestContextBuilder {
+ 
    std::string accept_language_;
    std::string user_agent_;
-   std::string proxy_url_;
 +  std::string resolver_rules_;
- 
++
    std::unique_ptr<HttpUserAgentSettings> http_user_agent_settings_;
  
+   std::optional<std::string> cookie_deprecation_label_;

--- a/native/03-tls_options.patch
+++ b/native/03-tls_options.patch
@@ -1,412 +1,51 @@
- .../api/src/org/chromium/net/CronetEngine.java     | 18 ++++++++++
- .../src/org/chromium/net/ICronetEngineBuilder.java |  6 ++++
- .../cronet/android/cronet_context_adapter.cc       |  3 ++
- .../net/impl/AndroidHttpEngineBuilderWrapper.java  | 24 +++++++++++++
- .../chromium/net/impl/CronetEngineBuilderImpl.java | 33 +++++++++++++++++
- .../chromium/net/impl/CronetUrlRequestContext.java | 12 +++++++
- .../android/proto/request_context_config.proto     |  3 ++
- .../cronet_sample_apk/CronetSampleApplication.java |  6 ++++
- .../ExperimentalOptionsTranslationTestUtil.java    | 15 ++++++++
- components/cronet/native/cronet.idl                |  7 ++++
- components/cronet/native/engine.cc                 |  3 ++
- components/cronet/native/generated/cronet.idl_c.h  | 18 ++++++++++
- .../native/generated/cronet.idl_impl_struct.cc     | 36 +++++++++++++++++++
- .../native/generated/cronet.idl_impl_struct.h      |  3 ++
- components/cronet/native/sample/main.cc            |  3 ++
- components/cronet/url_request_context_config.cc    | 41 ++++++++++++++++++++++
- components/cronet/url_request_context_config.h     | 23 ++++++++++++
- net/ssl/ssl_config_service_defaults.cc             |  5 +++
- net/ssl/ssl_config_service_defaults.h              |  2 ++
- 19 files changed, 261 insertions(+)
+ components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleApplication.java |  4 ++++
+ components/cronet/native/sample/main.cc                                                          |  2 ++
+ components/cronet/url_request_context_config.cc                                                  | 59 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ components/cronet/url_request_context_config.h                                                   |  1 +
+ net/ssl/ssl_config_service_defaults.cc                                                           |  4 ++++
+ net/ssl/ssl_config_service_defaults.h                                                            |  2 ++
+ 6 files changed, 72 insertions(+)
 
-diff --git a/components/cronet/android/api/src/org/chromium/net/CronetEngine.java b/components/cronet/android/api/src/org/chromium/net/CronetEngine.java
-index d97ae131dc6f1..c4d58e576ced7 100644
---- a/components/cronet/android/api/src/org/chromium/net/CronetEngine.java
-+++ b/components/cronet/android/api/src/org/chromium/net/CronetEngine.java
-@@ -135,6 +135,24 @@ public abstract class CronetEngine {
-         /** Reference to the actual builder implementation. {@hide exclude from JavaDoc}. */
-         protected final ICronetEngineBuilder mBuilderDelegate;
- 
-+        /**
-+         * Additional arguments to configure the url request context.
-+         */
-+        public Builder setDisabledCipherSuites(String disabledCipherSuites) {
-+            mBuilderDelegate.setDisabledCipherSuites(disabledCipherSuites);
-+            return this;
-+        }
-+
-+        public Builder setMinSslVersion(Short minSslVersion) {
-+            mBuilderDelegate.setMinSslVersion(minSslVersion);
-+            return this;
-+        }
-+
-+        public Builder setMaxSslVersion(Short maxSslVersion) {
-+            mBuilderDelegate.setMaxSslVersion(maxSslVersion);
-+            return this;
-+        }
-+
-         /**
-          * A string argument to be passed into MappedHostResolver->SetRulesFromString. It can
-          * be used to create direct mappings from domains to ips that override dns lookups.
-diff --git a/components/cronet/android/api/src/org/chromium/net/ICronetEngineBuilder.java b/components/cronet/android/api/src/org/chromium/net/ICronetEngineBuilder.java
-index 0dd5753e64404..d76e3194efe98 100644
---- a/components/cronet/android/api/src/org/chromium/net/ICronetEngineBuilder.java
-+++ b/components/cronet/android/api/src/org/chromium/net/ICronetEngineBuilder.java
-@@ -79,6 +79,12 @@ public abstract class ICronetEngineBuilder {
- 
-     public abstract ICronetEngineBuilder setResolverRules(String resolverRules);
- 
-+    public abstract ICronetEngineBuilder setDisabledCipherSuites(String disabledSuites);
-+
-+    public abstract ICronetEngineBuilder setMinSslVersion(Short minVersion);
-+
-+    public abstract ICronetEngineBuilder setMaxSslVersion(Short maxVersion);
-+
-     public abstract String getDefaultUserAgent();
- 
-     public abstract ExperimentalCronetEngine build();
-diff --git a/components/cronet/android/cronet_context_adapter.cc b/components/cronet/android/cronet_context_adapter.cc
-index ce696deaa53c4..baa63e9ceda4d 100644
---- a/components/cronet/android/cronet_context_adapter.cc
-+++ b/components/cronet/android/cronet_context_adapter.cc
-@@ -255,6 +255,9 @@ static jlong JNI_CronetUrlRequestContext_CreateRequestContextConfig(
-           /* accept_languages */ std::string(), configOptions.user_agent(),
-           configOptions.proxy_url(),
-           configOptions.resolver_rules(),
-+          configOptions.disabled_cipher_suites(),
-+          configOptions.min_ssl_version(),
-+          configOptions.max_ssl_version(),
-           configOptions.experimental_options(),
-           base::WrapUnique(reinterpret_cast<net::CertVerifier*>(
-               configOptions.mock_cert_verifier())),
-diff --git a/components/cronet/android/java/src/org/chromium/net/impl/AndroidHttpEngineBuilderWrapper.java b/components/cronet/android/java/src/org/chromium/net/impl/AndroidHttpEngineBuilderWrapper.java
-index ec2d4ef033ff6..08fc12e4f7090 100644
---- a/components/cronet/android/java/src/org/chromium/net/impl/AndroidHttpEngineBuilderWrapper.java
-+++ b/components/cronet/android/java/src/org/chromium/net/impl/AndroidHttpEngineBuilderWrapper.java
-@@ -63,6 +63,30 @@ class AndroidHttpEngineBuilderWrapper extends ICronetEngineBuilder {
-         return this;
-     }
- 
-+    @Override
-+    public ICronetEngineBuilder setDisabledCipherSuites(String disabledCipherSuites) {
-+        // need to implement abstract method, but mBackend 
-+        // class has not been updated with new parameters
-+        // mBackend.setDisabledCipherSuites(disabledCipherSuites);
-+        return this;
-+    }
-+
-+    @Override
-+    public ICronetEngineBuilder setMinSslVersion(Short minSslVersion) {
-+        // need to implement abstract method, but mBackend 
-+        // class has not been updated with new parameters
-+        // mBackend.setMinSslVersion(minSslVersion);
-+        return this;
-+    }
-+
-+    @Override
-+    public ICronetEngineBuilder setMaxSslVersion(Short maxSslVersion) {
-+        // need to implement abstract method, but mBackend 
-+        // class has not been updated with new parameters
-+        // mBackend.setMaxSslVersion(maxSslVersion);
-+        return this;
-+    }
-+
-     @Override
-     public ICronetEngineBuilder setStoragePath(String value) {
-         mBackend.setStoragePath(value);
-diff --git a/components/cronet/android/java/src/org/chromium/net/impl/CronetEngineBuilderImpl.java b/components/cronet/android/java/src/org/chromium/net/impl/CronetEngineBuilderImpl.java
-index 6bf8d9a1ea536..c9e171e26da36 100644
---- a/components/cronet/android/java/src/org/chromium/net/impl/CronetEngineBuilderImpl.java
-+++ b/components/cronet/android/java/src/org/chromium/net/impl/CronetEngineBuilderImpl.java
-@@ -144,6 +144,9 @@ public abstract class CronetEngineBuilderImpl extends ICronetEngineBuilder {
-     private String mUserAgent;
-     private String mProxyUrl;
-     private String mResolverRules;
-+    private String mDisabledCipherSuites;
-+    private Short mMinSslVersion;
-+    private Short mMaxSslVersion;
-     private String mStoragePath;
-     private boolean mQuicEnabled;
-     private boolean mHttp2Enabled;
-@@ -254,6 +257,36 @@ public abstract class CronetEngineBuilderImpl extends ICronetEngineBuilder {
-         return mResolverRules;
-     }
- 
-+    @Override
-+    public CronetEngineBuilderImpl setDisabledCipherSuites(String disabledCipherSuites) {
-+        mDisabledCipherSuites = disabledCipherSuites;
-+        return this;
-+    }
-+
-+    public String getDisabledCipherSuites() {
-+        return mDisabledCipherSuites;
-+    }
-+
-+    @Override
-+    public CronetEngineBuilderImpl setMinSslVersion(Short minSslVersion) {
-+        mMinSslVersion = minSslVersion;
-+        return this;
-+    }
-+
-+    public Short getMinSslVersion() {
-+        return mMinSslVersion;
-+    }
-+
-+    @Override
-+    public CronetEngineBuilderImpl setMaxSslVersion(Short maxSslVersion) {
-+        mMaxSslVersion = maxSslVersion;
-+        return this;
-+    }
-+
-+    public Short getMaxSslVersion() {
-+        return mMaxSslVersion;
-+    }
-+
-     @Override
-     public CronetEngineBuilderImpl setStoragePath(String value) {
-         if (!new File(value).isDirectory()) {
-diff --git a/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java b/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java
-index 690b2d4e8d1c6..a2b879d4a0b02 100644
---- a/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java
-+++ b/components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java
-@@ -427,6 +427,18 @@ public class CronetUrlRequestContext extends CronetEngineBase {
-             resultBuilder.setResolverRules(engineBuilder.getResolverRules());
-         }
- 
-+        if (engineBuilder.getDisabledCipherSuites() != null) {
-+            resultBuilder.setDisabledCipherSuites(engineBuilder.getDisabledCipherSuites());
-+        }
-+
-+        if (engineBuilder.getMinSslVersion() != null) {
-+            resultBuilder.setMinSslVersion(engineBuilder.getMinSslVersion());
-+        }
-+
-+        if (engineBuilder.getMaxSslVersion() != null) {
-+            resultBuilder.setMaxSslVersion(engineBuilder.getMaxSslVersion());
-+        }
-+
-         return resultBuilder.build();
-     }
- 
-diff --git a/components/cronet/android/proto/request_context_config.proto b/components/cronet/android/proto/request_context_config.proto
-index 6d9df5f9ebcd9..7b16726042dd3 100644
---- a/components/cronet/android/proto/request_context_config.proto
-+++ b/components/cronet/android/proto/request_context_config.proto
-@@ -21,6 +21,9 @@ message RequestContextConfigOptions {
-   optional bool enable_network_quality_estimator = 12;
-   optional bool bypass_public_key_pinning_for_local_trust_anchors = 13;
-   optional int32 network_thread_priority = 14;
-+  optional string disabled_cipher_suites = 100;
-+  optional int32 min_ssl_version = 101;
-+  optional int32 max_ssl_version = 102;
-   optional string proxy_url = 15;
-   optional string resolver_rules = 16;
- }
 diff --git a/components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleApplication.java b/components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleApplication.java
-index c8c06e94ee7a5..55e3dce2e77b4 100644
+index 87436d5a2d90c..7962e1dbd70dc 100644
 --- a/components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleApplication.java
 +++ b/components/cronet/android/sample/src/org/chromium/cronet_sample_apk/CronetSampleApplication.java
-@@ -26,6 +26,9 @@ public class CronetSampleApplication extends Application {
+@@ -24,6 +24,8 @@ public class CronetSampleApplication extends Application {
+         myBuilder
+                 .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_IN_MEMORY, 100 * 1024)
                  .enableHttp2(true)
-                 .setProxyUrl("socks5://127.0.0.1:1080")
-                 .setResolverRules("MAP * 208.80.154.224")
-+                .setDisabledCipherSuites("0xc024,0xc02f,0002")
-+                .setMinSslVersion((short)0x0303) // net::SSL_PROTOCOL_VERSION_TLS1_2
-+                .setMaxSslVersion((short)0x0304) // net::SSL_PROTOCOL_VERSION_TLS1_3
++                // net::SSL_PROTOCOL_VERSION_TLS1_2/3 -> hex value 0x0303/4
++                .setExperimentalOptions("{\"ssl_config\": {\"disabled_cipher_suites\": \"0xc024,0xc02f,0002\",\"min_ssl_version\": 771,\"max_ssl_version\": 772}}");
                  .enableQuic(true);
          mCronetEngine = myBuilder.build();
      }
-@@ -63,6 +66,9 @@ public class CronetSampleApplication extends Application {
+@@ -61,6 +63,8 @@ public class CronetSampleApplication extends Application {
                          .setDnsOptions(dnsOptionsBuilder)
                          .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_IN_MEMORY, 100 * 1024)
                          .enableHttp2(true)
-+                        .setDisabledCipherSuites("0xc024,0xc02f,0002")
-+                        .setMinSslVersion((short)771) // net::SSL_PROTOCOL_VERSION_TLS1_2 -> hex value 0x0303
-+                        .setMaxSslVersion((short)772) // net::SSL_PROTOCOL_VERSION_TLS1_3 -> hex value 0x0304
++                        // net::SSL_PROTOCOL_VERSION_TLS1_2/3 -> hex value 0x0303/4
++                        .setExperimentalOptions("{\"ssl_config\": {\"disabled_cipher_suites\": \"0xc024,0xc02f,0002\",\"min_ssl_version\": 771,\"max_ssl_version\": 772}}");
                          .enableQuic(true)
-                         .setProxyUrl("socks5://127.0.0.1:1080")
-                         .setResolverRules("MAP * 208.80.154.224")
-diff --git a/components/cronet/android/test/javatests/src/org/chromium/net/ExperimentalOptionsTranslationTestUtil.java b/components/cronet/android/test/javatests/src/org/chromium/net/ExperimentalOptionsTranslationTestUtil.java
-index 27455a11f4553..5a45ee409a201 100644
---- a/components/cronet/android/test/javatests/src/org/chromium/net/ExperimentalOptionsTranslationTestUtil.java
-+++ b/components/cronet/android/test/javatests/src/org/chromium/net/ExperimentalOptionsTranslationTestUtil.java
-@@ -200,6 +200,21 @@ public class ExperimentalOptionsTranslationTestUtil {
-             throw new UnsupportedOperationException();
-         }
- 
-+        @Override
-+        public ICronetEngineBuilder setDisabledCipherSuites(String disabledSuites) {
-+            throw new UnsupportedOperationException();
-+        }
-+
-+        @Override
-+        public ICronetEngineBuilder setMinSslVersion(Short minVersion) {
-+            throw new UnsupportedOperationException();
-+        }
-+
-+        @Override
-+        public ICronetEngineBuilder setMaxSslVersion(Short maxVersion) {
-+            throw new UnsupportedOperationException();
-+        }
-+
-         @Override
-         public ICronetEngineBuilder setConnectionMigrationOptions(
-                 ConnectionMigrationOptions options) {
-diff --git a/components/cronet/native/cronet.idl b/components/cronet/native/cronet.idl
-index d991bcb3277b4..f2e4d8e81c347 100644
---- a/components/cronet/native/cronet.idl
-+++ b/components/cronet/native/cronet.idl
-@@ -511,6 +511,13 @@ struct EngineParams {
-    */
-   string user_agent;
- 
-+  /**
-+   * Additional arguments to configure the url request context.
-+   */
-+  string disabled_cipher_suites;
-+  uint16_t min_ssl_version;
-+  uint16_t max_ssl_version;
-+
-   /**
-    * A string argument to be passed into MappedHostResolver->SetRulesFromString. It can
-    * be used to create direct mappings from domains to ips that override dns lookups.
-diff --git a/components/cronet/native/engine.cc b/components/cronet/native/engine.cc
-index 1590dda780a2a..09d956ffdf446 100644
---- a/components/cronet/native/engine.cc
-+++ b/components/cronet/native/engine.cc
-@@ -151,6 +151,9 @@ Cronet_RESULT Cronet_EngineImpl::StartWithParams(
-   context_config_builder.user_agent = params->user_agent;
-   context_config_builder.proxy_url = params->proxy_url;
-   context_config_builder.resolver_rules = params->resolver_rules;
-+  context_config_builder.disabled_cipher_suites = params->disabled_cipher_suites;
-+  context_config_builder.min_ssl_version = params->min_ssl_version;
-+  context_config_builder.max_ssl_version = params->max_ssl_version;
-   context_config_builder.experimental_options = params->experimental_options;
-   context_config_builder.bypass_public_key_pinning_for_local_trust_anchors =
-       params->enable_public_key_pinning_bypass_for_local_trust_anchors;
-diff --git a/components/cronet/native/generated/cronet.idl_c.h b/components/cronet/native/generated/cronet.idl_c.h
-index 76822f773a0c4..e53aa73159c78 100644
---- a/components/cronet/native/generated/cronet.idl_c.h
-+++ b/components/cronet/native/generated/cronet.idl_c.h
-@@ -801,6 +801,15 @@ CRONET_EXPORT
- void Cronet_EngineParams_resolver_rules_set(Cronet_EngineParamsPtr self,
-                                         const Cronet_String resolver_rules);
- CRONET_EXPORT
-+void Cronet_EngineParams_disabled_cipher_suites_set(Cronet_EngineParamsPtr self,
-+                                        const Cronet_String disabled_cipher_suites);
-+CRONET_EXPORT
-+void Cronet_EngineParams_min_ssl_version_set(Cronet_EngineParamsPtr self,
-+                                        const uint16_t min_ssl_version);
-+CRONET_EXPORT
-+void Cronet_EngineParams_max_ssl_version_set(Cronet_EngineParamsPtr self,
-+                                        const uint16_t max_ssl_version);
-+CRONET_EXPORT
- void Cronet_EngineParams_accept_language_set(
-     Cronet_EngineParamsPtr self,
-     const Cronet_String accept_language);
-@@ -857,6 +866,15 @@ CRONET_EXPORT
- Cronet_String Cronet_EngineParams_resolver_rules_get(
-     const Cronet_EngineParamsPtr self);
- CRONET_EXPORT
-+Cronet_String Cronet_EngineParams_disabled_cipher_suites_get(
-+    const Cronet_EngineParamsPtr self);
-+CRONET_EXPORT
-+uint16_t Cronet_EngineParams_min_ssl_version_get(
-+    const Cronet_EngineParamsPtr self);
-+CRONET_EXPORT
-+uint16_t Cronet_EngineParams_max_ssl_version_get(
-+    const Cronet_EngineParamsPtr self);
-+CRONET_EXPORT
- Cronet_String Cronet_EngineParams_accept_language_get(
-     const Cronet_EngineParamsPtr self);
- CRONET_EXPORT
-diff --git a/components/cronet/native/generated/cronet.idl_impl_struct.cc b/components/cronet/native/generated/cronet.idl_impl_struct.cc
-index 5f19a306b0ec1..d3555c3d46d1e 100644
---- a/components/cronet/native/generated/cronet.idl_impl_struct.cc
-+++ b/components/cronet/native/generated/cronet.idl_impl_struct.cc
-@@ -261,6 +261,24 @@ void Cronet_EngineParams_resolver_rules_set(Cronet_EngineParamsPtr self,
-   self->resolver_rules = resolver_rules;
- }
- 
-+void Cronet_EngineParams_disabled_cipher_suites_set(Cronet_EngineParamsPtr self,
-+                                        const Cronet_String disabled_cipher_suites) {
-+  DCHECK(self);
-+  self->disabled_cipher_suites = disabled_cipher_suites;
-+}
-+
-+void Cronet_EngineParams_min_ssl_version_set(Cronet_EngineParamsPtr self,
-+                                        const uint16_t min_ssl_version) {
-+  DCHECK(self);
-+  self->min_ssl_version = min_ssl_version;
-+}
-+
-+void Cronet_EngineParams_max_ssl_version_set(Cronet_EngineParamsPtr self,
-+                                        const uint16_t max_ssl_version) {
-+  DCHECK(self);
-+  self->max_ssl_version = max_ssl_version;
-+}
-+
- void Cronet_EngineParams_accept_language_set(
-     Cronet_EngineParamsPtr self,
-     const Cronet_String accept_language) {
-@@ -366,6 +384,24 @@ Cronet_String Cronet_EngineParams_resolver_rules_get(
-   return self->resolver_rules.c_str();
- }
- 
-+Cronet_String Cronet_EngineParams_disabled_cipher_suites_get(
-+    const Cronet_EngineParamsPtr self) {
-+  DCHECK(self);
-+  return self->disabled_cipher_suites.c_str();
-+}
-+
-+uint16_t Cronet_EngineParams_min_ssl_version_get(
-+    const Cronet_EngineParamsPtr self) {
-+  DCHECK(self);
-+  return self->min_ssl_version;
-+}
-+
-+uint16_t Cronet_EngineParams_max_ssl_version_get(
-+    const Cronet_EngineParamsPtr self) {
-+  DCHECK(self);
-+  return self->max_ssl_version;
-+}
-+
- Cronet_String Cronet_EngineParams_accept_language_get(
-     const Cronet_EngineParamsPtr self) {
-   DCHECK(self);
-diff --git a/components/cronet/native/generated/cronet.idl_impl_struct.h b/components/cronet/native/generated/cronet.idl_impl_struct.h
-index 3694104c6ce92..c9112eaa0f552 100644
---- a/components/cronet/native/generated/cronet.idl_impl_struct.h
-+++ b/components/cronet/native/generated/cronet.idl_impl_struct.h
-@@ -84,6 +84,9 @@ struct Cronet_EngineParams {
-   std::string user_agent;
-   std::string proxy_url;
-   std::string resolver_rules;
-+  std::string disabled_cipher_suites;
-+  uint16_t min_ssl_version;
-+  uint16_t max_ssl_version;
-   std::string accept_language;
-   std::string storage_path;
-   bool enable_quic = true;
+                         .build();
+     }
 diff --git a/components/cronet/native/sample/main.cc b/components/cronet/native/sample/main.cc
-index a484ac5ab9482..5bf6d5f853c81 100644
+index fe9ff6f1ee279..32ee3bcded0ac 100644
 --- a/components/cronet/native/sample/main.cc
 +++ b/components/cronet/native/sample/main.cc
-@@ -14,6 +14,9 @@ Cronet_EnginePtr CreateCronetEngine() {
+@@ -17,6 +17,8 @@ Cronet_EnginePtr CreateCronetEngine() {
+   Cronet_EnginePtr cronet_engine = Cronet_Engine_Create();
+   Cronet_EngineParamsPtr engine_params = Cronet_EngineParams_Create();
    Cronet_EngineParams_user_agent_set(engine_params, "CronetSample/1");
-   Cronet_EngineParams_proxy_url_set(engine_params, "socks5://127.0.0.1:1080");
-   Cronet_EngineParams_resolver_rules_set(engine_params, "MAP * 208.80.154.224");
-+  Cronet_EngineParams_disabled_cipher_suites_set(engine_params, "0xc024,0xc02f,0002");
-+  Cronet_EngineParams_min_ssl_version_set(engine_params, 0x0303); // TLS 1.2
-+  Cronet_EngineParams_max_ssl_version_set(engine_params, 0x0304); // TLS 1.3
++  // net::SSL_PROTOCOL_VERSION_TLS1_2/3 -> hex value 0x0303/4
++  Cronet_EngineParams_experimental_options_set(engine_params, "{\"ssl_config\": {\"disabled_cipher_suites\": \"0xc024,0xc02f,0002\",\"min_ssl_version\": 771,\"max_ssl_version\": 772}}");
    Cronet_EngineParams_enable_quic_set(engine_params, true);
  
    Cronet_Engine_StartWithParams(cronet_engine, engine_params);
 diff --git a/components/cronet/url_request_context_config.cc b/components/cronet/url_request_context_config.cc
-index 3c0c0aee2eb96..85922aa08e95f 100644
+index 8da024badd93a..ffa84da2e9869 100644
 --- a/components/cronet/url_request_context_config.cc
 +++ b/components/cronet/url_request_context_config.cc
-@@ -33,6 +33,9 @@
+@@ -37,6 +37,9 @@
  #include "net/nqe/network_quality_estimator_params.h"
  #include "net/quic/set_quic_flag.h"
  #include "net/socket/ssl_client_socket.h"
@@ -414,93 +53,83 @@ index 3c0c0aee2eb96..85922aa08e95f 100644
 +#include "net/ssl/ssl_config.h"
 +#include "net/ssl/ssl_config_service_defaults.h"
  #include "net/ssl/ssl_key_logger_impl.h"
+ #include "net/third_party/quiche/src/quiche/quic/core/crypto/crypto_protocol.h"
  #include "net/third_party/quiche/src/quiche/quic/core/quic_packets.h"
- #include "net/third_party/quiche/src/quiche/quic/core/quic_tag.h"
-@@ -266,6 +269,9 @@ URLRequestContextConfig::URLRequestContextConfig(
-     const std::string& user_agent,
-     const std::string& proxy_url,
-     const std::string& resolver_rules,
-+    const std::string& disabled_cipher_suites,
-+    const uint16_t min_ssl_version,
-+    const uint16_t max_ssl_version,
-     base::Value::Dict experimental_options,
-     std::unique_ptr<net::CertVerifier> mock_cert_verifier,
-     bool enable_network_quality_estimator,
-@@ -282,6 +288,9 @@ URLRequestContextConfig::URLRequestContextConfig(
-       user_agent(user_agent),
-       proxy_url(proxy_url),
-       resolver_rules(resolver_rules),
-+       disabled_cipher_suites(disabled_cipher_suites),
-+      min_ssl_version(min_ssl_version),
-+      max_ssl_version(max_ssl_version),
-       mock_cert_verifier(std::move(mock_cert_verifier)),
-       enable_network_quality_estimator(enable_network_quality_estimator),
-       bypass_public_key_pinning_for_local_trust_anchors(
-@@ -310,6 +319,9 @@ URLRequestContextConfig::CreateURLRequestContextConfig(
-     const std::string& user_agent,
-     const std::string& proxy_url,
-     const std::string& resolver_rules,
-+    const std::string& disabled_cipher_suites,
-+    const uint16_t min_ssl_version,
-+    const uint16_t max_ssl_version,
-     const std::string& unparsed_experimental_options,
-     std::unique_ptr<net::CertVerifier> mock_cert_verifier,
-     bool enable_network_quality_estimator,
-@@ -328,6 +340,7 @@ URLRequestContextConfig::CreateURLRequestContextConfig(
-   return base::WrapUnique(new URLRequestContextConfig(
-       enable_quic, enable_spdy, enable_brotli, http_cache, http_cache_max_size,
-       load_disable_cache, storage_path, accept_language, user_agent, proxy_url, resolver_rules,
-+      disabled_cipher_suites, min_ssl_version, max_ssl_version,
-       std::move(experimental_options).value(), std::move(mock_cert_verifier),
-       enable_network_quality_estimator,
-       bypass_public_key_pinning_for_local_trust_anchors,
-@@ -807,6 +820,33 @@ void URLRequestContextConfig::ConfigureURLRequestContextBuilder(
-   context_builder->set_user_agent(user_agent);
-   context_builder->set_proxy_url(proxy_url);
-   context_builder->set_resolver_rules(resolver_rules);
-+  net::SSLContextConfig ssl_context_config;
-+  if (!disabled_cipher_suites.empty()) {
-+    auto cipher_strings = base::SplitString(disabled_cipher_suites, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
-+    // see net::ParseCipherSuites(cipher_strings);
-+    std::vector<uint16_t> cipher_suites;
-+    cipher_suites.reserve(cipher_strings.size());
+@@ -211,6 +214,9 @@ const char kDisableTlsZeroRtt[] = "disable_tls_zero_rtt";
+ // underlying OS.
+ const char kSpdyGoAwayOnIpChange[] = "spdy_go_away_on_ip_change";
+ 
++// cipher suite/ssl version options
++const char kSslConfig[] = "ssl_config";
 +
-+    for (auto it = cipher_strings.begin(); it != cipher_strings.end(); ++it) {
-+      uint16_t cipher_suite = 0;
-+      if (!net::ParseSSLCipherString(*it, &cipher_suite)) {
+ // Whether the connection status of all bidirectional streams (created through
+ // the Cronet engine) should be monitored.
+ // The value must be an integer (> 0) and will be interpreted as a suggestion
+@@ -765,6 +771,59 @@ void URLRequestContextConfig::SetContextBuilderExperimentalOptions(
+         continue;
+       }
+       session_params->spdy_go_away_on_ip_change = iter->second.GetBool();
++    } else if (iter->first == kSslConfig) {
++      if (!iter->second.is_dict()) {
++        LOG(ERROR) << "\"" << iter->first << "\" config params \""
++                   << iter->second << "\" is not a dict value";
++        effective_experimental_options.Remove(iter->first);
 +        continue;
 +      }
-+      cipher_suites.push_back(cipher_suite);
-+    }
-+    std::sort(cipher_suites.begin(), cipher_suites.end());
 +
-+    ssl_context_config.disabled_cipher_suites =  cipher_suites;
-+  } 
++      // decode ssl config
++      // there's a fromDict(), but dict types may not be compatible?
 +
-+  if (min_ssl_version != net::kDefaultSSLVersionMin) {
-+    ssl_context_config.version_min = min_ssl_version;
-+  } 
-+  if (max_ssl_version != net::kDefaultSSLVersionMax) {
-+    ssl_context_config.version_max = max_ssl_version;
-+  } 
-+  auto ssl_config_service_ptr = std::make_unique<net::SSLConfigServiceDefaults>(ssl_context_config);
-+  context_builder->set_ssl_config_service(std::move(ssl_config_service_ptr));
-   net::HttpNetworkSessionParams session_params;
-   session_params.enable_http2 = enable_spdy;
-   session_params.enable_quic = enable_quic;
-@@ -837,6 +877,7 @@ URLRequestContextConfigBuilder::Build() {
-   return URLRequestContextConfig::CreateURLRequestContextConfig(
-       enable_quic, enable_spdy, enable_brotli, http_cache, http_cache_max_size,
-       load_disable_cache, storage_path, accept_language, user_agent, proxy_url, resolver_rules,
-+      disabled_cipher_suites, min_ssl_version, max_ssl_version,
-       experimental_options, std::move(mock_cert_verifier),
-       enable_network_quality_estimator,
-       bypass_public_key_pinning_for_local_trust_anchors,
++      // part of dict is delimited string, need to transfer values manually?
++      const base::Value::Dict& ssl_config = iter->second.GetDict();
++      const std::string* dict_disabled_cipher_suites = ssl_config.FindString("disabled_cipher_suites");
++      std::optional<int> dict_min_ssl_version = ssl_config.FindInt("min_ssl_version");
++      std::optional<int> dict_max_ssl_version = ssl_config.FindInt("max_ssl_version");
++
++      net::SSLContextConfig ssl_context_config;
++      std::string temp_disabled_cipher_suites = *dict_disabled_cipher_suites;
++      if (!temp_disabled_cipher_suites.empty()) {
++        auto cipher_strings = base::SplitString(temp_disabled_cipher_suites, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
++        // see net::ParseCipherSuites(cipher_strings);
++        std::vector<uint16_t> cipher_suites;
++        cipher_suites.reserve(cipher_strings.size());
++
++        for (auto it = cipher_strings.begin(); it != cipher_strings.end(); ++it) {
++          uint16_t cipher_suite = 0;
++          if (!net::ParseSSLCipherString(*it, &cipher_suite)) {
++            continue;
++          }
++          cipher_suites.push_back(cipher_suite);
++        }
++        std::sort(cipher_suites.begin(), cipher_suites.end());
++
++        ssl_context_config.disabled_cipher_suites =  cipher_suites;
++      }
++
++      if (dict_min_ssl_version.has_value()) {
++        int temp_min_ssl_version = dict_min_ssl_version.value();
++        if (temp_min_ssl_version >= 0 && temp_min_ssl_version <= UINT16_MAX) {
++          ssl_context_config.version_min = static_cast<uint16_t>(temp_min_ssl_version);
++        }
++      }
++      if (dict_max_ssl_version.has_value()) {
++        int temp_max_ssl_version = dict_max_ssl_version.value();
++        if (temp_max_ssl_version >= 0 && temp_max_ssl_version <= UINT16_MAX) {
++          ssl_context_config.version_max = static_cast<uint16_t>(temp_max_ssl_version);
++        }
++      }
++
++      auto ssl_config_service_ptr = std::make_unique<net::SSLConfigServiceDefaults>(ssl_context_config);
++      context_builder->set_ssl_config_service(std::move(ssl_config_service_ptr));
++
+     } else {
+       LOG(WARNING) << "Unrecognized Cronet experimental option \""
+                    << iter->first << "\" with params \"" << iter->second;
 diff --git a/components/cronet/url_request_context_config.h b/components/cronet/url_request_context_config.h
-index 11f8fe4c8f4c9..6d5657185eb2c 100644
+index 324525466cf24..b8daa6d8d35f8 100644
 --- a/components/cronet/url_request_context_config.h
 +++ b/components/cronet/url_request_context_config.h
-@@ -16,6 +16,7 @@
+@@ -17,6 +17,7 @@
  #include "net/base/network_handle.h"
  #include "net/cert/cert_verifier.h"
  #include "net/nqe/effective_connection_type.h"
@@ -508,67 +137,16 @@ index 11f8fe4c8f4c9..6d5657185eb2c 100644
  #include "url/origin.h"
  
  namespace net {
-@@ -133,6 +134,13 @@ struct URLRequestContextConfig {
-   // MappedHostResolver->SetRulesFromString argument
-   const std::string resolver_rules;
- 
-+  // cipher suite config field.
-+  const std::string disabled_cipher_suites;
-+
-+  // ssl version config fields.
-+  const uint16_t min_ssl_version;
-+  const uint16_t max_ssl_version;
-+
-   // Certificate verifier for testing.
-   std::unique_ptr<net::CertVerifier> mock_cert_verifier;
- 
-@@ -209,6 +217,11 @@ struct URLRequestContextConfig {
-       const std::string& proxy_url,
-       // MappedHostResolver->SetRulesFromString argument
-       const std::string& resolver_rules,
-+      // cipher suite config field.
-+      const std::string& disabled_cipher_suites,
-+      // ssl version config fields.
-+      const uint16_t min_ssl_version,
-+      const uint16_t max_ssl_version,
-       // JSON encoded experimental options.
-       const std::string& unparsed_experimental_options,
-       // MockCertVerifier to use for testing purposes.
-@@ -247,6 +260,11 @@ struct URLRequestContextConfig {
-       const std::string& proxy_url,
-       // MappedHostResolver->SetRulesFromString argument
-       const std::string& resolver_rules,
-+      // cipher suite config field.
-+      const std::string& disabled_cipher_suites,
-+      // ssl version config fields.
-+      const uint16_t min_ssl_version,
-+      const uint16_t max_ssl_version,
-       // Parsed experimental options.
-       base::Value::Dict experimental_options,
-       // MockCertVerifier to use for testing purposes.
-@@ -319,6 +337,11 @@ struct URLRequestContextConfigBuilder {
-   std::string proxy_url = "";
-   // MappedHostResolver->SetRulesFromString argument
-   std::string resolver_rules = "";
-+  // cipher suite config field.
-+  std::string disabled_cipher_suites = "";
-+  // ssl version config fields.
-+  uint16_t min_ssl_version = net::kDefaultSSLVersionMin;
-+  uint16_t max_ssl_version = net::kDefaultSSLVersionMax;
-   // Experimental options encoded as a string in a JSON format containing
-   // experiments and their corresponding configuration options. The format
-   // is a JSON object with the name of the experiment as the key, and the
 diff --git a/net/ssl/ssl_config_service_defaults.cc b/net/ssl/ssl_config_service_defaults.cc
-index 7d137e59662d3..099b4ef8209d7 100644
+index 7d137e59662d3..440ff49d0aba0 100644
 --- a/net/ssl/ssl_config_service_defaults.cc
 +++ b/net/ssl/ssl_config_service_defaults.cc
-@@ -9,6 +9,11 @@ namespace net {
+@@ -9,6 +9,10 @@ namespace net {
  SSLConfigServiceDefaults::SSLConfigServiceDefaults() = default;
  SSLConfigServiceDefaults::~SSLConfigServiceDefaults() = default;
  
 +SSLConfigServiceDefaults::SSLConfigServiceDefaults(SSLContextConfig default_config): default_config_(default_config) {
-+  // TODO: copied commented line from patch, delete?
-+  // default_config.disabled_cipher_suites = default_config_.disabled_cipher_suites;
++  // initialize with default config parameter
 +}
 +
  SSLContextConfig SSLConfigServiceDefaults::GetSSLContextConfig() {


### PR DESCRIPTION
replaced resolver rules and tls options patches with new ones that use experimental options.

updated envoy code that used old resolver rules method.  however CronetEngine.Builder().setExperimentalOptions() doesn't seem to exist in my current version of the cronet aar.

tls option features don't appear to be used at the moment so no changes were required there.